### PR TITLE
Prevent approval of condition attributes when edits are unsaved

### DIFF
--- a/condition-web/src/components/ConditionDetails/ConditionAttribute/ConditionAttributeTable.tsx
+++ b/condition-web/src/components/ConditionDetails/ConditionAttribute/ConditionAttributeTable.tsx
@@ -16,8 +16,7 @@ import {
   Select,
   Stack,
   MenuItem,
-  Paper,
-  Tooltip
+  Paper
 } from "@mui/material";
 import AddIcon from '@mui/icons-material/Add';
 import { BCDesignTokens } from "epic.theme";
@@ -59,6 +58,7 @@ const ConditionAttributeTable = memo(({
     const queryClient = useQueryClient();
     const [conditionAttributeError, setConditionAttributeError] = useState(false);
     const [isAnyRowEditing, setIsAnyRowEditing] = useState(false);
+    const [showEditingError, setShowEditingError] = useState(false);
 
     const onCreateFailure = () => {
       notify.error("Failed to save condition attributes");
@@ -132,6 +132,13 @@ const ConditionAttributeTable = memo(({
     }, [conditionAttributeDetails]);
 
     const approveConditionAttributes = () => {
+      if (isAnyRowEditing) {
+        setShowEditingError(true);
+        return;
+      }
+
+      setShowEditingError(false);
+
       /* Check if any condition attribute has a null or {} value except
          for management plan acronym as this is not mandatory */
       const hasInvalidAttributes = condition?.condition_attributes?.some(attr => 
@@ -464,16 +471,9 @@ const ConditionAttributeTable = memo(({
             </Paper>
           </Modal>
 
-          {origin != 'create' && <Box width="50%" sx={{ display: 'flex', justifyContent: 'flex-end' }}>
-            <Tooltip
-              title={
-                isAnyRowEditing
-                  ? "Please save your changes before approving attributes"
-                  : ""
-              }
-            >
-              {/* Span wrapper needed for tooltip to work on disabled buttons */}
-              <span>
+          {origin !== 'create' && (
+            <Box width="50%" sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+              <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end' }}>
                 <Button
                   variant="contained"
                   color="primary"
@@ -484,15 +484,27 @@ const ConditionAttributeTable = memo(({
                     borderRadius: "4px",
                   }}
                   onClick={approveConditionAttributes}
-                  disabled={isAnyRowEditing}
                 >
                   {condition.is_condition_attributes_approved
                     ? "Un-approve Condition Attributes"
                     : "Approve Condition Attributes"}
                 </Button>
-              </span>
-            </Tooltip>
-          </Box>}
+                {showEditingError && isAnyRowEditing && (
+                  <Box
+                    sx={{
+                      color: "#CE3E39",
+                      fontSize: "14px",
+                      marginTop: 1,
+                      marginBottom: "15px",
+                      textAlign: 'right',
+                    }}
+                  >
+                    Please save your changes before approving the Condition Attributes.
+                  </Box>
+                )}
+              </Box>
+            </Box>
+          )}
         </Stack>
       </Box>
     );

--- a/condition-web/src/components/ConditionDetails/ConditionDescription.tsx
+++ b/condition-web/src/components/ConditionDetails/ConditionDescription.tsx
@@ -35,6 +35,7 @@ const ConditionDescription = memo(({
   setIsLoading
 }: ConditionDescriptionProps) => {
   const [isEditing, setIsEditing] = useState(editMode);
+  const [showEditingError, setShowEditingError] = useState(false);
 
   const {
     subconditions,
@@ -90,6 +91,13 @@ const ConditionDescription = memo(({
   }, [conditionDetails]);
   
   const approveConditionDescription = () => {
+    if (isEditing) {
+      setShowEditingError(true);
+      return;
+    }
+
+    setShowEditingError(false);
+
     const data: updateTopicTagsModel = {
       is_approved: !isConditionApproved }
     updateConditionDetails(data);
@@ -142,20 +150,35 @@ const ConditionDescription = memo(({
           )}
         </Box>
         <Box width="50%" sx={{ display: 'flex', justifyContent: 'flex-end' }}>
-          <Button
-              variant="contained"
-              color="primary"
-              size="small"
-              sx={{
-                width: "260px", 
-                padding: "4px 8px",
-                borderRadius: "4px",
-              }}
-              onClick={approveConditionDescription}
-          >
-            {isConditionApproved ?
-            'Un-approve Condition Requirements' : 'Approve Condition Requirements'}
-          </Button>
+          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end' }}>
+            <Button
+                variant="contained"
+                color="primary"
+                size="small"
+                sx={{
+                  width: "260px", 
+                  padding: "4px 8px",
+                  borderRadius: "4px",
+                }}
+                onClick={approveConditionDescription}
+            >
+              {isConditionApproved ?
+              'Un-approve Condition Requirements' : 'Approve Condition Requirements'}
+            </Button>
+            {showEditingError && isEditing && (
+              <Box
+                sx={{
+                  color: "#CE3E39",
+                  fontSize: "14px",
+                  marginTop: 1,
+                  marginBottom: "15px",
+                  textAlign: 'right',
+                }}
+              >
+                Please navigate to the top of this section to save your changes before approving Condition Requirements.
+              </Box>
+            )}
+          </Box>
         </Box>
       </Stack>
     </Box>


### PR DESCRIPTION
Ticket: https://eao-dst.atlassian.net/browse/CR-110

- Added logic to prevent approval of condition attributes when edits are unsaved