### PR TITLE
Update subcondition nesting and reorder interactions

### DIFF
--- a/condition-api/src/condition_api/services/condition_service.py
+++ b/condition-api/src/condition_api/services/condition_service.py
@@ -360,8 +360,8 @@ class ConditionService:
             ConditionService._update_from_dict(condition, conditions_data)
 
         # Handle subconditions
-        if subconditions := conditions_data.get("subconditions"):
-            ConditionService._update_subconditions(condition_id, subconditions)
+        if "subconditions" in conditions_data:
+            ConditionService._update_subconditions(condition_id, conditions_data.get("subconditions") or [])
 
         condition.commit()
         return condition
@@ -437,18 +437,36 @@ class ConditionService:
 
     @staticmethod
     def _update_subconditions(condition_id, subconditions):
-        existing_ids = [
-            sub["subcondition_id"]
-            for sub in subconditions
-            if isinstance(sub.get("subcondition_id"), str) and "-" not in sub["subcondition_id"]
-        ]
+        existing_ids = ConditionService._collect_existing_subcondition_ids(subconditions)
 
-        db.session.query(Subcondition).filter(
-            Subcondition.condition_id == condition_id,
-            Subcondition.id.notin_(existing_ids)
-        ).delete(synchronize_session=False)
+        delete_query = db.session.query(Subcondition).filter(
+            Subcondition.condition_id == condition_id
+        )
+
+        if existing_ids:
+            delete_query = delete_query.filter(Subcondition.id.notin_(existing_ids))
+
+        delete_query.delete(synchronize_session=False)
 
         ConditionService.upsert_subconditions(condition_id, subconditions, None)
+
+    @staticmethod
+    def _collect_existing_subcondition_ids(subconditions):
+        existing_ids = []
+
+        for subcondition in subconditions:
+            subcondition_id = subcondition.get("subcondition_id")
+
+            if str(subcondition_id).isdigit():
+                existing_ids.append(int(subcondition_id))
+
+            existing_ids.extend(
+                ConditionService._collect_existing_subcondition_ids(
+                    subcondition.get("subconditions") or []
+                )
+            )
+
+        return existing_ids
 
     @staticmethod
     def _update_from_dict(condition_item: Condition, input_dict: dict):

--- a/condition-api/tests/unit/services/test_condition_service.py
+++ b/condition-api/tests/unit/services/test_condition_service.py
@@ -1,0 +1,92 @@
+"""Tests for condition service subcondition updates."""
+
+import uuid
+
+from condition_api.models.subcondition import Subcondition
+from condition_api.services.condition_service import ConditionService
+from tests.utilities.factory_utils import (
+    factory_condition_model,
+    factory_document_model,
+    factory_project_model,
+    get_seeded_document_type,
+)
+
+
+def test_update_condition_reparents_nested_subconditions(session):
+    """Updating nested subconditions keeps existing descendants and parent links."""
+    project = factory_project_model(project_id=str(uuid.uuid4()))
+    doc_type = get_seeded_document_type("Certificate")
+    document = factory_document_model(project_id=project.project_id, document_type_id=doc_type.id)
+    condition = factory_condition_model(project_id=project.project_id, document_id=document.document_id)
+
+    parent = Subcondition(
+        condition_id=condition.id,
+        subcondition_identifier="1.1",
+        subcondition_text="Parent",
+        sort_order=1,
+    )
+    session.add(parent)
+    session.flush()
+
+    child = Subcondition(
+        condition_id=condition.id,
+        parent_subcondition_id=parent.id,
+        subcondition_identifier="1.1.1",
+        subcondition_text="Child",
+        sort_order=1,
+    )
+    session.add(child)
+    session.commit()
+
+    payload = {
+        "subconditions": [
+            {
+                "subcondition_id": str(parent.id),
+                "subcondition_identifier": "1.1",
+                "subcondition_text": "Parent updated",
+                "subconditions": [
+                    {
+                        "subcondition_id": str(child.id),
+                        "subcondition_identifier": "1.1.1",
+                        "subcondition_text": "Child updated",
+                        "subconditions": [],
+                    }
+                ],
+            }
+        ]
+    }
+
+    ConditionService.update_condition(payload, condition.id, False, False)
+
+    session.expire_all()
+    updated_parent = session.get(Subcondition, parent.id)
+    updated_child = session.get(Subcondition, child.id)
+
+    assert updated_parent is not None
+    assert updated_parent.subcondition_text == "Parent updated"
+    assert updated_child is not None
+    assert updated_child.subcondition_text == "Child updated"
+    assert updated_child.parent_subcondition_id == parent.id
+
+
+def test_update_condition_allows_clearing_subconditions(session):
+    """Sending an empty subcondition list removes existing subconditions."""
+    project = factory_project_model(project_id=str(uuid.uuid4()))
+    doc_type = get_seeded_document_type("Certificate")
+    document = factory_document_model(project_id=project.project_id, document_type_id=doc_type.id)
+    condition = factory_condition_model(project_id=project.project_id, document_id=document.document_id)
+
+    session.add(
+        Subcondition(
+            condition_id=condition.id,
+            subcondition_identifier="1.1",
+            subcondition_text="To remove",
+            sort_order=1,
+        )
+    )
+    session.commit()
+
+    ConditionService.update_condition({"subconditions": []}, condition.id, False, False)
+
+    remaining = session.query(Subcondition).filter(Subcondition.condition_id == condition.id).all()
+    assert remaining == []

--- a/condition-web/src/components/ConditionDetails/ConditionDescription.tsx
+++ b/condition-web/src/components/ConditionDetails/ConditionDescription.tsx
@@ -2,7 +2,6 @@ import { memo, useEffect, useState, useCallback, useRef } from 'react';
 import { Box, Typography, Button, Stack } from "@mui/material";
 import AddIcon from '@mui/icons-material/Add';
 import { ConditionModel } from "@/models/Condition";
-import { SubconditionModel } from "@/models/Subcondition";
 import { theme } from "@/styles/theme";
 import { useUpdateConditionDetails } from "@/hooks/api/useConditions";
 import { notify } from "@/components/Shared/Snackbar/snackbarStore";
@@ -15,9 +14,14 @@ import { useSubconditionHandler } from "@/hooks/api/useSubconditionHandler";
 import {
   DragDropContext,
   Droppable,
-  Draggable,
   DropResult
 } from '@hello-pangea/dnd';
+import {
+  indentSubcondition,
+  reorderSubconditions,
+  outdentSubcondition,
+  ROOT_DROPPABLE_ID,
+} from "./subconditionTree";
 
 type ConditionDescriptionProps = {
   editMode: boolean;
@@ -46,6 +50,7 @@ const ConditionDescription = memo(({
   const queryClient = useQueryClient();
   const [isEditing, setIsEditing] = useState(editMode);
   const [showEditingError, setShowEditingError] = useState(false);
+  const [activeDroppableId, setActiveDroppableId] = useState<string | null>(null);
 
   const {
     subconditions,
@@ -141,86 +146,39 @@ const ConditionDescription = memo(({
     updateConditionDetails(data);
   };
 
-  const buildSortOrderMap = (
-    items: SubconditionModel[],
-    parentId: string = "null",
-    map: Record<string, number> = {}
-  ): Record<string, number> => {
-    return items.reduce((acc, item, index) => {
-      const key = `${parentId}-${item.subcondition_id}`;
-      acc[key] = index;
-      return item.subconditions?.length
-        ? buildSortOrderMap(item.subconditions, item.subcondition_id, acc)
-        : acc;
-    }, map);
-  };
-
-  const applySortOrder = (
-    nodes: SubconditionModel[],
-    sortOrderMap: Record<string, number>,
-    parentId: string | null = null
-  ): SubconditionModel[] => {
-    const apply = (items: SubconditionModel[], parentId: string): SubconditionModel[] => {
-      return items
-        .map((item) => ({
-          ...item,
-          subconditions: item.subconditions
-            ? apply(item.subconditions, item.subcondition_id)
-            : [],
-        }))
-        .sort((a, b) => {
-          const keyA = `${parentId}-${a.subcondition_id}`;
-          const keyB = `${parentId}-${b.subcondition_id}`;
-          return (sortOrderMap[keyA] ?? 0) - (sortOrderMap[keyB] ?? 0);
-        });
-    };
-  
-    return apply(nodes, parentId ?? "null");
-  };
-
-  const reorderNested = (
-    items: SubconditionModel[],
-    parentId: string | null,
-    sourceIndex: number,
-    destinationIndex: number
-  ): SubconditionModel[] => {
-    if (parentId === "subconditions-droppable") {
-      const newItems = [...items];
-      const [moved] = newItems.splice(sourceIndex, 1);
-      newItems.splice(destinationIndex, 0, moved);
-      return newItems;
-    }
-  
-    return items.map((item) => {
-      if (item.subcondition_id === parentId && item.subconditions) {
-        const newSub = [...item.subconditions];
-        const [moved] = newSub.splice(sourceIndex, 1);
-        newSub.splice(destinationIndex, 0, moved);
-        return {
-          ...item,
-          subconditions: newSub,
-        };
-      }
-      return {
-        ...item,
-        subconditions: item.subconditions
-          ? reorderNested(item.subconditions, parentId, sourceIndex, destinationIndex)
-          : [],
-      };
-    });
-  }; 
-
   const handleDragEnd = (result: DropResult) => {
-    if (!result.destination) return;
-  
-    const sourceId = result.source.droppableId;
-    const sourceIndex = result.source.index;
-    const destinationIndex = result.destination.index;
-  
-    const reordered = reorderNested(subconditions, sourceId, sourceIndex, destinationIndex);
-    const sortOrderMap = buildSortOrderMap(reordered);
-    const sorted = applySortOrder(reordered, sortOrderMap);
-    setSubconditions(sorted);
+    setActiveDroppableId(null);
+
+    const { source, destination } = result;
+
+    if (!destination) {
+      return;
+    }
+
+    if (source.droppableId !== destination.droppableId) {
+      return;
+    }
+
+    setSubconditions(
+      reorderSubconditions(
+        subconditions,
+        source.droppableId,
+        source.index,
+        destination.index
+      )
+    );
+  };
+
+  const handleDragStart = (start: { source: { droppableId: string } }) => {
+    setActiveDroppableId(start.source.droppableId);
+  };
+
+  const handleIndent = (subconditionId: string) => {
+    setSubconditions(indentSubcondition(subconditions, subconditionId));
+  };
+
+  const handleOutdent = (subconditionId: string) => {
+    setSubconditions(outdentSubcondition(subconditions, subconditionId));
   };
 
   if (!condition) {
@@ -229,41 +187,36 @@ const ConditionDescription = memo(({
 
   return (
     <Box>
-      <DragDropContext onDragEnd={handleDragEnd}>
-      <Droppable droppableId="subconditions-droppable" type="SUBCONDITION">
+      <DragDropContext onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+      <Droppable
+        droppableId={ROOT_DROPPABLE_ID}
+        type="SUBCONDITION"
+        isDropDisabled={
+          activeDroppableId !== null && activeDroppableId !== ROOT_DROPPABLE_ID
+        }
+      >
         {(provided) => (
           <div
             {...provided.droppableProps}
             ref={provided.innerRef}
           >
             {subconditions.map((sub, index) => (
-              <Draggable
+              <SubconditionComponent
                 key={sub.subcondition_id}
-                draggableId={sub.subcondition_id}
+                subcondition={sub}
                 index={index}
-                isDragDisabled={!isEditing}
-              >
-                {(dragProvided) => (
-                  <div
-                    ref={dragProvided.innerRef}
-                    {...dragProvided.draggableProps}
-                    {...dragProvided.dragHandleProps}
-                    style={{ ...dragProvided.draggableProps.style }}
-                  >
-                    <SubconditionComponent
-                      subcondition={sub}
-                      indentLevel={1}
-                      isEditing={isEditing}
-                      onEdit={handleEdit}
-                      onDelete={handleDelete}
-                      onAdd={handleAdd}
-                      identifierValue={sub.subcondition_identifier || ""}
-                      textValue={sub.subcondition_text || ""}
-                      is_approved={isConditionApproved || false}
-                    />
-                  </div>
-                )}
-              </Draggable>
+                indentLevel={1}
+                isEditing={isEditing}
+                onEdit={handleEdit}
+                onDelete={handleDelete}
+                onAdd={handleAdd}
+                onIndent={handleIndent}
+                onOutdent={handleOutdent}
+                activeDroppableId={activeDroppableId}
+                identifierValue={sub.subcondition_identifier || ""}
+                textValue={sub.subcondition_text || ""}
+                is_approved={isConditionApproved || false}
+              />
             ))}
             {provided.placeholder}
           </div>

--- a/condition-web/src/components/ConditionDetails/CreateCondition/CreateConditionInfoTabs.tsx
+++ b/condition-web/src/components/ConditionDetails/CreateCondition/CreateConditionInfoTabs.tsx
@@ -7,9 +7,14 @@ import { theme } from "@/styles/theme";
 import SubconditionComponent from "../SubCondition";
 import { useSubconditionHandler } from "@/hooks/api/useSubconditionHandler";
 import { ConditionModel } from "@/models/Condition";
-import { SubconditionModel } from "@/models/Subcondition";
 import ConditionAttribute from '../ConditionAttribute';
-import { DragDropContext, DropResult } from '@hello-pangea/dnd';
+import { DragDropContext, DropResult, Droppable } from '@hello-pangea/dnd';
+import {
+    indentSubcondition,
+    reorderSubconditions,
+    outdentSubcondition,
+    ROOT_DROPPABLE_ID
+} from "../subconditionTree";
 
 const StyledTabs = styled(Tabs)({
     transition: 'none',
@@ -48,6 +53,7 @@ const CreateConditionInfoTabs: React.FC<{
     isCreateMode?: boolean;
 }> = ({ condition, setCondition, isCreateMode = false }) => {
     const [selectedTab, setSelectedTab] = useState('requirements');
+    const [activeDroppableId, setActiveDroppableId] = useState<string | null>(null);
 
     const handleTabChange = (_: React.SyntheticEvent, newValue: string) => {
         setSelectedTab(newValue);
@@ -62,86 +68,39 @@ const CreateConditionInfoTabs: React.FC<{
         setSubconditions,
       } = useSubconditionHandler(condition.subconditions || []);
 
-    const buildSortOrderMap = (
-        items: SubconditionModel[],
-        parentId: string = "null",
-        map: Record<string, number> = {}
-    ): Record<string, number> => {
-        return items.reduce((acc, item, index) => {
-          const key = `${parentId}-${item.subcondition_id}`;
-          acc[key] = index;
-          return item.subconditions?.length
-            ? buildSortOrderMap(item.subconditions, item.subcondition_id, acc)
-            : acc;
-        }, map);
-    };
-      
-    const applySortOrder = (
-        nodes: SubconditionModel[],
-        sortOrderMap: Record<string, number>,
-        parentId: string | null = null
-    ): SubconditionModel[] => {
-        const apply = (items: SubconditionModel[], parentId: string): SubconditionModel[] => {
-          return items
-            .map((item) => ({
-              ...item,
-              subconditions: item.subconditions
-                ? apply(item.subconditions, item.subcondition_id)
-                : [],
-            }))
-            .sort((a, b) => {
-              const keyA = `${parentId}-${a.subcondition_id}`;
-              const keyB = `${parentId}-${b.subcondition_id}`;
-              return (sortOrderMap[keyA] ?? 0) - (sortOrderMap[keyB] ?? 0);
-            });
-        };
-      
-        return apply(nodes, parentId ?? "null");
-    };
-    
-    const reorderNested = (
-        items: SubconditionModel[],
-        parentId: string | null,
-        sourceIndex: number,
-        destinationIndex: number
-    ): SubconditionModel[] => {
-        if (parentId === "subconditions-droppable") {
-          const newItems = [...items];
-          const [moved] = newItems.splice(sourceIndex, 1);
-          newItems.splice(destinationIndex, 0, moved);
-          return newItems;
-        }
-      
-        return items.map((item) => {
-          if (item.subcondition_id === parentId && item.subconditions) {
-            const newSub = [...item.subconditions];
-            const [moved] = newSub.splice(sourceIndex, 1);
-            newSub.splice(destinationIndex, 0, moved);
-            return {
-              ...item,
-              subconditions: newSub,
-            };
-          }
-          return {
-            ...item,
-            subconditions: item.subconditions
-              ? reorderNested(item.subconditions, parentId, sourceIndex, destinationIndex)
-              : [],
-          };
-        });
-    }; 
-    
     const handleDragEnd = (result: DropResult) => {
-        if (!result.destination) return;
-    
-        const sourceId = result.source.droppableId;
-        const sourceIndex = result.source.index;
-        const destinationIndex = result.destination.index;
-    
-        const reordered = reorderNested(subconditions, sourceId, sourceIndex, destinationIndex);
-        const sortOrderMap = buildSortOrderMap(reordered);
-        const sorted = applySortOrder(reordered, sortOrderMap);
-        setSubconditions(sorted);
+        setActiveDroppableId(null);
+
+        const { source, destination } = result;
+
+        if (!destination) {
+            return;
+        }
+
+        if (source.droppableId !== destination.droppableId) {
+            return;
+        }
+
+        setSubconditions(
+            reorderSubconditions(
+                subconditions,
+                source.droppableId,
+                source.index,
+                destination.index
+            )
+        );
+    };
+
+    const handleDragStart = (start: { source: { droppableId: string } }) => {
+        setActiveDroppableId(start.source.droppableId);
+    };
+
+    const handleIndent = (subconditionId: string) => {
+        setSubconditions(indentSubcondition(subconditions, subconditionId));
+    };
+
+    const handleOutdent = (subconditionId: string) => {
+        setSubconditions(outdentSubcondition(subconditions, subconditionId));
     };
 
     useEffect(() => {
@@ -172,21 +131,38 @@ const CreateConditionInfoTabs: React.FC<{
             </Stack>
             <Box sx={{ p: 2 }}>
                 <Box sx={{ display: selectedTab === 'requirements' ? 'block' : 'none' }}>
-                    <DragDropContext onDragEnd={handleDragEnd}>
-                        {subconditions.map((sub, index) => (
-                            <SubconditionComponent
-                                key={index}
-                                subcondition={sub}
-                                indentLevel={1}
-                                isEditing={true}
-                                onEdit={handleEdit}
-                                onDelete={handleDelete}
-                                onAdd={handleAdd}
-                                identifierValue={sub.subcondition_identifier || ""}
-                                textValue={sub.subcondition_text || ""}
-                                is_approved={false}
-                            />
-                        ))}
+                    <DragDropContext onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+                        <Droppable
+                            droppableId={ROOT_DROPPABLE_ID}
+                            type="SUBCONDITION"
+                            isDropDisabled={
+                                activeDroppableId !== null && activeDroppableId !== ROOT_DROPPABLE_ID
+                            }
+                        >
+                            {(provided) => (
+                                <div ref={provided.innerRef} {...provided.droppableProps}>
+                                    {subconditions.map((sub, index) => (
+                                        <SubconditionComponent
+                                            key={sub.subcondition_id}
+                                            subcondition={sub}
+                                            index={index}
+                                            indentLevel={1}
+                                            isEditing={true}
+                                            onEdit={handleEdit}
+                                            onDelete={handleDelete}
+                                            onAdd={handleAdd}
+                                            onIndent={handleIndent}
+                                            onOutdent={handleOutdent}
+                                            activeDroppableId={activeDroppableId}
+                                            identifierValue={sub.subcondition_identifier || ""}
+                                            textValue={sub.subcondition_text || ""}
+                                            is_approved={false}
+                                        />
+                                    ))}
+                                    {provided.placeholder}
+                                </div>
+                            )}
+                        </Droppable>
                     </DragDropContext>
                     <Stack sx={{ mt: 5 }} direction={"row"}>
                         <Box width="50%" sx={{ display: 'flex', justifyContent: 'flex-start' }}>

--- a/condition-web/src/components/ConditionDetails/SubCondition.tsx
+++ b/condition-web/src/components/ConditionDetails/SubCondition.tsx
@@ -1,4 +1,4 @@
-import { Box, IconButton, Typography, TextField } from "@mui/material";
+import { Box, IconButton, TextField, Tooltip, Typography } from "@mui/material";
 import { SubconditionModel } from "@/models/Subcondition";
 import { theme } from "@/styles/theme";
 import AddIcon from '@mui/icons-material/Add';
@@ -94,24 +94,48 @@ const SubconditionComponent: React.FC<{
                   InputProps={{ sx: { padding: '4px 8px', fontSize: '14px' } }}
                 />
                 <Box display="flex" alignItems="center" sx={{ paddingLeft: '4px', paddingBottom: 3 }}>
-                  <IconButton
-                    size="small"
-                    onClick={() => onOutdent(subcondition.subcondition_id)}
-                    disabled={indentLevel === 1}
-                  >
-                    <Typography variant="body2" sx={{ fontWeight: 700, lineHeight: 1 }}>
-                      ←
-                    </Typography>
-                  </IconButton>
-                  <IconButton
-                    size="small"
-                    onClick={() => onIndent(subcondition.subcondition_id)}
-                    disabled={index === 0}
-                  >
-                    <Typography variant="body2" sx={{ fontWeight: 700, lineHeight: 1 }}>
-                      →
-                    </Typography>
-                  </IconButton>
+                  {indentLevel > 1 && (
+                    <Tooltip title="Move out one level">
+                      <span>
+                        <IconButton
+                          size="small"
+                          onClick={() => onOutdent(subcondition.subcondition_id)}
+                          aria-label="Move out one level"
+                          sx={{
+                            borderRadius: "4px",
+                            "&:hover": {
+                              backgroundColor: theme.palette.action.hover,
+                            },
+                          }}
+                        >
+                          <Typography variant="body2" sx={{ fontWeight: 700, fontSize: "1rem", lineHeight: 1 }}>
+                            ⟵
+                          </Typography>
+                        </IconButton>
+                      </span>
+                    </Tooltip>
+                  )}
+                  {index > 0 && (
+                    <Tooltip title="Make child of item above">
+                      <span>
+                        <IconButton
+                          size="small"
+                          onClick={() => onIndent(subcondition.subcondition_id)}
+                          aria-label="Make child of item above"
+                          sx={{
+                            borderRadius: "4px",
+                            "&:hover": {
+                              backgroundColor: theme.palette.action.hover,
+                            },
+                          }}
+                        >
+                          <Typography variant="body2" sx={{ fontWeight: 700, fontSize: "1rem", lineHeight: 1 }}>
+                            ⟶
+                          </Typography>
+                        </IconButton>
+                      </span>
+                    </Tooltip>
+                  )}
                   <IconButton size="small" onClick={() => onAdd(subcondition.subcondition_id)}>
                     <AddIcon fontSize="small" />
                   </IconButton>

--- a/condition-web/src/components/ConditionDetails/SubCondition.tsx
+++ b/condition-web/src/components/ConditionDetails/SubCondition.tsx
@@ -9,26 +9,32 @@ import { Droppable, Draggable } from '@hello-pangea/dnd';
 
 const SubconditionComponent: React.FC<{
   subcondition: SubconditionModel;
+  index: number;
   indentLevel: number;
   isEditing: boolean;
   onEdit: (id: string, newIdentifier: string, newText: string) => void;
   onDelete: (id: string) => void;
   onAdd: (parentId: string) => void;
+  onIndent: (id: string) => void;
+  onOutdent: (id: string) => void;
+  activeDroppableId: string | null;
   identifierValue: string;
   textValue: string;
   is_approved: boolean;
-  dragHandleProps?: React.HTMLAttributes<HTMLDivElement>;
 }> = ({
   subcondition,
+  index,
   indentLevel,
   isEditing,
   onEdit,
   onDelete,
   onAdd,
+  onIndent,
+  onOutdent,
+  activeDroppableId,
   identifierValue,
   textValue,
   is_approved,
-  dragHandleProps,
 }) => {
 
   const handleIdentifierChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -40,101 +46,128 @@ const SubconditionComponent: React.FC<{
   };
 
   return (
-    <>
-      <Box
-        sx={{
-          padding: '8px 12px',
-          backgroundColor: is_approved ? '#F7F9FC' : BCDesignTokens.themeGray10,
-          borderRadius: '3px',
-          border: `1px solid ${theme.palette.primary.light}`,
-          marginBottom: '10px',
-          marginLeft: indentLevel > 1 ? `${indentLevel * 20}px` : '0px',
-          display: 'flex',
-          gap: '8px'
-        }}
-      >
-        {isEditing && (
-          <div {...dragHandleProps} style={{ cursor: 'grab', paddingRight: 4 }}>
-            <DragIndicatorIcon fontSize="small" />
-          </div>
-        )}
-        {isEditing ? (
-          <>
-            <TextField
-              variant="outlined"
-              value={identifierValue}
-              onChange={handleIdentifierChange}
-              sx={{ width: '100px' }}
-            />
-            <TextField
-              variant="outlined"
-              multiline
-              fullWidth
-              value={textValue}
-              onChange={handleTextChange}
-              InputProps={{ sx: { padding: '4px 8px', fontSize: '14px' } }}
-            />
-            <Box display="flex" alignItems="center" sx={{ paddingLeft: '4px', paddingBottom: 3 }}>
-              <IconButton size="small" onClick={() => onAdd(subcondition.subcondition_id)}>
-                <AddIcon fontSize="small" />
-              </IconButton>
-              <IconButton size="small" onClick={() => onDelete(subcondition.subcondition_id)}>
-                <Delete fontSize="small" />
-              </IconButton>
-            </Box>
-          </>
-        ) : (
-          <Typography variant="body2">
-            {subcondition.subcondition_identifier && (
-              <span style={{ color: theme.palette.primary.dark, marginRight: '8px' }}>
-                {subcondition.subcondition_identifier.endsWith(')')
-                  ? subcondition.subcondition_identifier
-                  : `${subcondition.subcondition_identifier})`}
-              </span>
-            )}
-            {subcondition.subcondition_text}
-          </Typography>
-        )}
-      </Box>
-
-      {/* Nested Droppable */}
-      <Droppable droppableId={subcondition.subcondition_id} type="SUBCONDITION">
-        {(provided) => (
-          <div ref={provided.innerRef} {...provided.droppableProps}>
-            {subcondition.subconditions?.map((nestedSub, index) => (
-              <Draggable
-                key={nestedSub.subcondition_id}
-                draggableId={nestedSub.subcondition_id}
-                index={index}
-                isDragDisabled={!isEditing}
+    <Draggable
+      draggableId={subcondition.subcondition_id}
+      index={index}
+      isDragDisabled={!isEditing}
+    >
+      {(dragProvided) => (
+        <div
+          ref={dragProvided.innerRef}
+          {...dragProvided.draggableProps}
+          style={{ ...dragProvided.draggableProps.style }}
+        >
+          <Box
+            sx={{
+              padding: '8px 12px',
+              backgroundColor: is_approved ? '#F7F9FC' : BCDesignTokens.themeGray10,
+              borderRadius: '3px',
+              border: `1px solid ${theme.palette.primary.light}`,
+              marginBottom: '10px',
+              marginLeft: indentLevel > 1 ? `${indentLevel * 20}px` : '0px',
+              display: 'flex',
+              gap: '8px'
+            }}
+          >
+            {isEditing && (
+              <div
+                {...dragProvided.dragHandleProps}
+                style={{ cursor: 'grab', paddingRight: 4 }}
               >
-                {(dragProvided) => (
-                  <div
-                    ref={dragProvided.innerRef}
-                    {...dragProvided.draggableProps}
-                    style={{ ...dragProvided.draggableProps.style }}
+                <DragIndicatorIcon fontSize="small" />
+              </div>
+            )}
+            {isEditing ? (
+              <>
+                <TextField
+                  variant="outlined"
+                  value={identifierValue}
+                  onChange={handleIdentifierChange}
+                  sx={{ width: '100px' }}
+                />
+                <TextField
+                  variant="outlined"
+                  multiline
+                  fullWidth
+                  value={textValue}
+                  onChange={handleTextChange}
+                  InputProps={{ sx: { padding: '4px 8px', fontSize: '14px' } }}
+                />
+                <Box display="flex" alignItems="center" sx={{ paddingLeft: '4px', paddingBottom: 3 }}>
+                  <IconButton
+                    size="small"
+                    onClick={() => onOutdent(subcondition.subcondition_id)}
+                    disabled={indentLevel === 1}
                   >
-                    <SubconditionComponent
-                      subcondition={nestedSub}
-                      indentLevel={indentLevel + 1}
-                      isEditing={isEditing}
-                      onEdit={onEdit}
-                      onDelete={onDelete}
-                      onAdd={onAdd}
-                      identifierValue={nestedSub.subcondition_identifier}
-                      textValue={nestedSub.subcondition_text}
-                      is_approved={is_approved}
-                      dragHandleProps={dragProvided.dragHandleProps ?? undefined}
-                    />
-                  </div>
+                    <Typography variant="body2" sx={{ fontWeight: 700, lineHeight: 1 }}>
+                      ←
+                    </Typography>
+                  </IconButton>
+                  <IconButton
+                    size="small"
+                    onClick={() => onIndent(subcondition.subcondition_id)}
+                    disabled={index === 0}
+                  >
+                    <Typography variant="body2" sx={{ fontWeight: 700, lineHeight: 1 }}>
+                      →
+                    </Typography>
+                  </IconButton>
+                  <IconButton size="small" onClick={() => onAdd(subcondition.subcondition_id)}>
+                    <AddIcon fontSize="small" />
+                  </IconButton>
+                  <IconButton size="small" onClick={() => onDelete(subcondition.subcondition_id)}>
+                    <Delete fontSize="small" />
+                  </IconButton>
+                </Box>
+              </>
+            ) : (
+              <Typography variant="body2">
+                {subcondition.subcondition_identifier && (
+                  <span style={{ color: theme.palette.primary.dark, marginRight: '8px' }}>
+                    {subcondition.subcondition_identifier.endsWith(')')
+                      ? subcondition.subcondition_identifier
+                      : `${subcondition.subcondition_identifier})`}
+                  </span>
                 )}
-              </Draggable>
-            ))}
-            {provided.placeholder}
-          </div>
-        )}
-      </Droppable>
-    </>
+                {subcondition.subcondition_text}
+              </Typography>
+            )}
+          </Box>
+
+          <Droppable
+            droppableId={subcondition.subcondition_id}
+            type="SUBCONDITION"
+            isDropDisabled={
+              activeDroppableId !== null && activeDroppableId !== subcondition.subcondition_id
+            }
+          >
+            {(provided) => (
+              <div ref={provided.innerRef} {...provided.droppableProps}>
+                {subcondition.subconditions?.map((nestedSub, nestedIndex) => (
+                  <SubconditionComponent
+                    key={nestedSub.subcondition_id}
+                    subcondition={nestedSub}
+                    index={nestedIndex}
+                    indentLevel={indentLevel + 1}
+                    isEditing={isEditing}
+                    onEdit={onEdit}
+                    onDelete={onDelete}
+                    onAdd={onAdd}
+                    onIndent={onIndent}
+                    onOutdent={onOutdent}
+                    activeDroppableId={activeDroppableId}
+                    identifierValue={nestedSub.subcondition_identifier}
+                    textValue={nestedSub.subcondition_text}
+                    is_approved={is_approved}
+                  />
+                ))}
+                {provided.placeholder}
+              </div>
+            )}
+          </Droppable>
+        </div>
+      )}
+    </Draggable>
   );
 };
 

--- a/condition-web/src/components/ConditionDetails/subconditionTree.ts
+++ b/condition-web/src/components/ConditionDetails/subconditionTree.ts
@@ -1,0 +1,277 @@
+import { SubconditionModel } from "@/models/Subcondition";
+
+export const ROOT_DROPPABLE_ID = "subconditions-droppable";
+
+type NodeLocation = {
+  parentId: string;
+  index: number;
+};
+
+const cloneNodes = (nodes: SubconditionModel[]): SubconditionModel[] =>
+  nodes.map((node) => ({
+    ...node,
+    subconditions: cloneNodes(node.subconditions || []),
+  }));
+
+const normalizeSortOrder = (nodes: SubconditionModel[]): SubconditionModel[] =>
+  nodes.map((node, index) => ({
+    ...node,
+    sort_order: index + 1,
+    subconditions: normalizeSortOrder(node.subconditions || []),
+  }));
+
+const findNodeLocation = (
+  nodes: SubconditionModel[],
+  nodeId: string,
+  parentId = ROOT_DROPPABLE_ID
+): NodeLocation | null => {
+  for (let index = 0; index < nodes.length; index += 1) {
+    const node = nodes[index];
+
+    if (node.subcondition_id === nodeId) {
+      return { parentId, index };
+    }
+
+    const nestedLocation = findNodeLocation(
+      node.subconditions || [],
+      nodeId,
+      node.subcondition_id
+    );
+
+    if (nestedLocation) {
+      return nestedLocation;
+    }
+  }
+
+  return null;
+};
+
+const findNodeById = (
+  nodes: SubconditionModel[],
+  nodeId: string
+): SubconditionModel | undefined => {
+  for (const node of nodes) {
+    if (node.subcondition_id === nodeId) {
+      return node;
+    }
+
+    const nestedNode = findNodeById(node.subconditions || [], nodeId);
+    if (nestedNode) {
+      return nestedNode;
+    }
+  }
+
+  return undefined;
+};
+
+const reorderInParent = (
+  nodes: SubconditionModel[],
+  parentId: string,
+  fromIndex: number,
+  toIndex: number
+): SubconditionModel[] => {
+  if (parentId === ROOT_DROPPABLE_ID) {
+    const nextNodes = [...nodes];
+    const [movedNode] = nextNodes.splice(fromIndex, 1);
+    nextNodes.splice(toIndex, 0, movedNode);
+    return nextNodes;
+  }
+
+  return nodes.map((node) => {
+    if (node.subcondition_id === parentId) {
+      const nextChildren = [...(node.subconditions || [])];
+      const [movedNode] = nextChildren.splice(fromIndex, 1);
+      nextChildren.splice(toIndex, 0, movedNode);
+
+      return {
+        ...node,
+        subconditions: nextChildren,
+      };
+    }
+
+    return {
+      ...node,
+      subconditions: reorderInParent(node.subconditions || [], parentId, fromIndex, toIndex),
+    };
+  });
+};
+
+const removeFromParent = (
+  nodes: SubconditionModel[],
+  parentId: string,
+  index: number,
+  takeTrailingSiblings = false
+): {
+  tree: SubconditionModel[];
+  removedNode?: SubconditionModel;
+  trailingSiblings: SubconditionModel[];
+} => {
+  if (parentId === ROOT_DROPPABLE_ID) {
+    const nextNodes = [...nodes];
+    const [removedNode] = nextNodes.splice(index, 1);
+    const trailingSiblings = takeTrailingSiblings ? nextNodes.splice(index) : [];
+
+    return { tree: nextNodes, removedNode, trailingSiblings };
+  }
+
+  let removedNode: SubconditionModel | undefined;
+  let trailingSiblings: SubconditionModel[] = [];
+
+  const nextNodes = nodes.map((node) => {
+    if (node.subcondition_id === parentId) {
+      const nextChildren = [...(node.subconditions || [])];
+      [removedNode] = nextChildren.splice(index, 1);
+
+      if (takeTrailingSiblings) {
+        trailingSiblings = nextChildren.splice(index);
+      }
+
+      return {
+        ...node,
+        subconditions: nextChildren,
+      };
+    }
+
+    const nested = removeFromParent(node.subconditions || [], parentId, index, takeTrailingSiblings);
+    if (nested.removedNode) {
+      removedNode = nested.removedNode;
+      trailingSiblings = nested.trailingSiblings;
+    }
+
+    return {
+      ...node,
+      subconditions: nested.tree,
+    };
+  });
+
+  return { tree: nextNodes, removedNode, trailingSiblings };
+};
+
+const insertIntoParent = (
+  nodes: SubconditionModel[],
+  parentId: string,
+  index: number,
+  nodeToInsert: SubconditionModel
+): SubconditionModel[] => {
+  if (parentId === ROOT_DROPPABLE_ID) {
+    const nextNodes = [...nodes];
+    nextNodes.splice(index, 0, nodeToInsert);
+    return nextNodes;
+  }
+
+  return nodes.map((node) => {
+    if (node.subcondition_id === parentId) {
+      const nextChildren = [...(node.subconditions || [])];
+      nextChildren.splice(index, 0, nodeToInsert);
+
+      return {
+        ...node,
+        subconditions: nextChildren,
+      };
+    }
+
+    return {
+      ...node,
+      subconditions: insertIntoParent(node.subconditions || [], parentId, index, nodeToInsert),
+    };
+  });
+};
+
+export const reorderSubconditions = (
+  tree: SubconditionModel[],
+  parentId: string,
+  fromIndex: number,
+  toIndex: number
+): SubconditionModel[] => {
+  if (fromIndex === toIndex) {
+    return tree;
+  }
+
+  return normalizeSortOrder(
+    reorderInParent(cloneNodes(tree), parentId, fromIndex, toIndex)
+  );
+};
+
+export const indentSubcondition = (
+  tree: SubconditionModel[],
+  nodeId: string
+): SubconditionModel[] => {
+  const location = findNodeLocation(tree, nodeId);
+
+  if (!location || location.index === 0) {
+    return tree;
+  }
+
+  const nextTree = cloneNodes(tree);
+  const { tree: treeWithoutNode, removedNode } = removeFromParent(
+    nextTree,
+    location.parentId,
+    location.index
+  );
+
+  if (!removedNode) {
+    return tree;
+  }
+
+  const previousSiblingIndex = location.index - 1;
+  const siblings =
+    location.parentId === ROOT_DROPPABLE_ID
+      ? treeWithoutNode
+      : findNodeById(treeWithoutNode, location.parentId)?.subconditions || [];
+  const previousSibling = siblings[previousSiblingIndex];
+
+  if (!previousSibling) {
+    return tree;
+  }
+
+  const updatedTree = insertIntoParent(
+    treeWithoutNode,
+    previousSibling.subcondition_id,
+    (previousSibling.subconditions || []).length,
+    removedNode
+  );
+
+  return normalizeSortOrder(updatedTree);
+};
+
+export const outdentSubcondition = (
+  tree: SubconditionModel[],
+  nodeId: string
+): SubconditionModel[] => {
+  const location = findNodeLocation(tree, nodeId);
+
+  if (!location || location.parentId === ROOT_DROPPABLE_ID) {
+    return tree;
+  }
+
+  const parentLocation = findNodeLocation(tree, location.parentId);
+  if (!parentLocation) {
+    return tree;
+  }
+
+  const nextTree = cloneNodes(tree);
+  const { tree: treeWithoutNode, removedNode, trailingSiblings } = removeFromParent(
+    nextTree,
+    location.parentId,
+    location.index,
+    true
+  );
+
+  if (!removedNode) {
+    return tree;
+  }
+
+  const movedNode = {
+    ...removedNode,
+    subconditions: [...(removedNode.subconditions || []), ...trailingSiblings],
+  };
+
+  const updatedTree = insertIntoParent(
+    treeWithoutNode,
+    parentLocation.parentId,
+    parentLocation.index + 1,
+    movedNode
+  );
+
+  return normalizeSortOrder(updatedTree);
+};


### PR DESCRIPTION
## Summary
- add explicit subcondition indent/outdent controls for changing hierarchy levels
- limit drag-and-drop to reordering within the same parent level
- preserve trailing siblings as children when a subcondition is moved out one level
- update subcondition persistence logic in the API to handle nested tree updates and empty lists correctly
- add backend tests covering nested subcondition updates and removal

