### PR TITLE
CR-156:Export consolidated conditions as PDF

### DIFF
--- a/condition-api/src/condition_api/resources/consolidated_condition.py
+++ b/condition-api/src/condition_api/resources/consolidated_condition.py
@@ -27,6 +27,7 @@ from flask_restx import Namespace, Resource
 from marshmallow import ValidationError
 
 from condition_api.services import authorization
+from condition_api.services.amendment_service import AmendmentService
 from condition_api.services.condition_service import ConditionService
 from condition_api.services.docgen_service import TEMPLATE_KEY, DocGenService
 from condition_api.utils.util import allowedorigins, cors_preflight
@@ -51,18 +52,12 @@ def _fetch_logo_as_data_url(logo_url: str) -> str:
         return logo_url  # fall back to URL if fetch fails
 
 
-def _build_render_context(consolidated: dict) -> dict:
+def _build_render_context(consolidated: dict, project_id: str) -> dict:
     """Build the template context dict from consolidated conditions data."""
     conditions = consolidated.get("conditions", [])
     project_name = consolidated.get("project_name", "")
 
-    amendment_set = set()
-    for cond in conditions:
-        for part in (cond.get("amendment_names") or "").split(","):
-            trimmed = part.strip()
-            if trimmed:
-                amendment_set.add(trimmed)
-
+    amendment_names = AmendmentService.get_amendment_names_for_project(project_id)
     approved_count = sum(1 for c in conditions if c.get("is_approved"))
     now = datetime.now()
 
@@ -71,7 +66,7 @@ def _build_render_context(consolidated: dict) -> dict:
         "generated_on": now.strftime("%A, %B ") + str(now.day) + now.strftime(", %Y"),
         "generated_on_short": now.strftime("%B ") + str(now.day) + now.strftime(", %Y"),
         "total_conditions": len(conditions),
-        "amendment_list": ", ".join(sorted(amendment_set)),
+        "amendment_list": ", ".join(amendment_names),
         "all_approved": all(cond.get("is_approved") for cond in conditions),
         "approved_count": approved_count,
         "awaiting_count": len(conditions) - approved_count,
@@ -154,7 +149,7 @@ class ConsolidatedConditionRenderResource(Resource):
             if not consolidated:
                 return {"message": "No conditions found for this project"}, HTTPStatus.NOT_FOUND
 
-            context = _build_render_context(consolidated)
+            context = _build_render_context(consolidated, project_id)
             docgen_response = DocGenService.render_template(TEMPLATE_KEY, context, output_format)
 
             if output_format == "pdf":

--- a/condition-api/src/condition_api/services/amendment_service.py
+++ b/condition-api/src/condition_api/services/amendment_service.py
@@ -57,6 +57,22 @@ class AmendmentService:
         return new_amendment
 
     @staticmethod
+    def get_amendments_for_project(project_id: str) -> list:
+        """Return all amendments for a given project from the database."""
+        return (
+            db.session.query(Amendment)
+            .join(Document, Amendment.document_id == Document.id)
+            .filter(Document.project_id == project_id)
+            .all()
+        )
+
+    @staticmethod
+    def get_amendment_names_for_project(project_id: str) -> list[str]:
+        """Return sorted unique amendment names for a given project."""
+        amendments = AmendmentService.get_amendments_for_project(project_id)
+        return sorted({a.amendment_name for a in amendments if a.amendment_name})
+
+    @staticmethod
     def _update_document(document_id, is_latest_amendment_added):
         """Update a SQLAlchemy model instance from a dictionary."""
         document = Document.get_by_id(document_id)


### PR DESCRIPTION
Changes: Fetch amendment names for PDF from database

Previously, the consolidated conditions PDF derived the "Included Amendments" list by parsing comma-separated amendment_names strings aggregated on each condition. This replaces that logic with a direct DB query — get_amendments_for_project fetches Amendment records joined through Document by project_id, and get_amendment_names_for_project extracts the unique sorted names from those objects