### PR TITLE
CR-169:Consolidated Conditions: 'Year Condition Issued' field to reflect the most recent amendment

### DIFF
--- a/condition-api/src/condition_api/resources/consolidated_condition.py
+++ b/condition-api/src/condition_api/resources/consolidated_condition.py
@@ -48,8 +48,8 @@ def _fetch_logo_as_data_url(logo_url: str) -> str:
         content_type = response.headers.get("Content-Type", "image/png").split(";")[0]
         b64 = base64.b64encode(response.content).decode("utf-8")
         return f"data:{content_type};base64,{b64}"
-    except Exception:  # pylint: disable=broad-except
-        return logo_url  # fall back to URL if fetch fails
+    except Exception:
+        return logo_url
 
 
 def _build_render_context(consolidated: dict, project_id: str) -> dict:
@@ -165,5 +165,5 @@ class ConsolidatedConditionRenderResource(Resource):
 
         except ValidationError as err:
             return {"message": str(err)}, HTTPStatus.BAD_REQUEST
-        except Exception as err:  # pylint: disable=broad-except
+        except Exception as err:
             return {"message": f"Failed to generate PDF: {str(err)}"}, HTTPStatus.INTERNAL_SERVER_ERROR

--- a/condition-api/src/condition_api/resources/consolidated_condition.py
+++ b/condition-api/src/condition_api/resources/consolidated_condition.py
@@ -167,6 +167,7 @@ class ConsolidatedConditionRenderResource(Resource):
         except ValidationError as err:
             return {"message": str(err)}, HTTPStatus.BAD_REQUEST
         except http_requests.exceptions.RequestException as err:
-            return {"message": f"Failed to reach document generation service: {str(err)}"}, HTTPStatus.INTERNAL_SERVER_ERROR
+            return {"message": f"Failed to reach document generation service: {str(err)}"}, \
+                HTTPStatus.INTERNAL_SERVER_ERROR
         except SQLAlchemyError as err:
             return {"message": f"Database error: {str(err)}"}, HTTPStatus.INTERNAL_SERVER_ERROR

--- a/condition-api/src/condition_api/resources/consolidated_condition.py
+++ b/condition-api/src/condition_api/resources/consolidated_condition.py
@@ -25,6 +25,7 @@ from flask_cors import cross_origin
 from flask_restx import Namespace, Resource
 
 from marshmallow import ValidationError
+from sqlalchemy.exc import SQLAlchemyError
 
 from condition_api.services import authorization
 from condition_api.services.amendment_service import AmendmentService
@@ -48,7 +49,7 @@ def _fetch_logo_as_data_url(logo_url: str) -> str:
         content_type = response.headers.get("Content-Type", "image/png").split(";")[0]
         b64 = base64.b64encode(response.content).decode("utf-8")
         return f"data:{content_type};base64,{b64}"
-    except Exception:
+    except http_requests.exceptions.RequestException:
         return logo_url
 
 
@@ -165,5 +166,7 @@ class ConsolidatedConditionRenderResource(Resource):
 
         except ValidationError as err:
             return {"message": str(err)}, HTTPStatus.BAD_REQUEST
-        except Exception as err:
-            return {"message": f"Failed to generate PDF: {str(err)}"}, HTTPStatus.INTERNAL_SERVER_ERROR
+        except http_requests.exceptions.RequestException as err:
+            return {"message": f"Failed to reach document generation service: {str(err)}"}, HTTPStatus.INTERNAL_SERVER_ERROR
+        except SQLAlchemyError as err:
+            return {"message": f"Database error: {str(err)}"}, HTTPStatus.INTERNAL_SERVER_ERROR

--- a/condition-api/src/condition_api/services/condition_service.py
+++ b/condition-api/src/condition_api/services/condition_service.py
@@ -855,6 +855,23 @@ class ConditionService:
             )
         )
 
+        latest_amendment_subquery = (
+            db.session.query(
+                DocumentCategory.id.label("category_id"),
+                Condition.condition_number,
+                func.max(Amendment.date_issued).label("latest_amendment_date"),
+            )
+            .select_from(Project)
+            .join(Document, Document.project_id == Project.project_id)
+            .join(DocumentType, DocumentType.id == Document.document_type_id)
+            .join(DocumentCategory, DocumentCategory.id == DocumentType.document_category_id)
+            .join(Amendment, Amendment.document_id == Document.id)
+            .join(Condition, Condition.amended_document_id == Amendment.amended_document_id)
+            .filter(filter_condition)
+            .group_by(DocumentCategory.id, Condition.condition_number)
+            .subquery()
+        )
+
         if user_is_internal:
             amendment_subquery = (
                 db.session.query(
@@ -882,7 +899,11 @@ class ConditionService:
                 Document.id,
                 Document.document_id,
                 DocumentCategory.category_name,
-                extract("year", Document.date_issued).label("year_issued"),
+                case(
+                    (latest_amendment_subquery.c.latest_amendment_date.isnot(None),
+                     extract("year", latest_amendment_subquery.c.latest_amendment_date)),
+                    else_=extract("year", Document.date_issued),
+                ).label("year_issued"),
                 Condition.id.label("condition_id"),
                 Condition.condition_name,
                 Condition.condition_number,
@@ -906,6 +927,13 @@ class ConditionService:
             .join(DocumentCategory, DocumentCategory.id == DocumentType.document_category_id)
             .join(Condition, Condition.document_id == Document.document_id)
             .outerjoin(Amendment, Amendment.amended_document_id == Condition.amended_document_id)
+            .outerjoin(
+                latest_amendment_subquery,
+                and_(
+                    Condition.condition_number == latest_amendment_subquery.c.condition_number,
+                    DocumentCategory.id == latest_amendment_subquery.c.category_id,
+                ),
+            )
             .filter(filter_condition)
             .filter(Condition.is_active.is_(True))
         )

--- a/condition-api/src/condition_api/services/condition_service.py
+++ b/condition-api/src/condition_api/services/condition_service.py
@@ -857,18 +857,16 @@ class ConditionService:
 
         latest_amendment_subquery = (
             db.session.query(
-                DocumentCategory.id.label("category_id"),
+                Document.document_id.label("document_id"),
                 Condition.condition_number,
                 func.max(Amendment.date_issued).label("latest_amendment_date"),
             )
             .select_from(Project)
             .join(Document, Document.project_id == Project.project_id)
-            .join(DocumentType, DocumentType.id == Document.document_type_id)
-            .join(DocumentCategory, DocumentCategory.id == DocumentType.document_category_id)
             .join(Amendment, Amendment.document_id == Document.id)
             .join(Condition, Condition.amended_document_id == Amendment.amended_document_id)
             .filter(filter_condition)
-            .group_by(DocumentCategory.id, Condition.condition_number)
+            .group_by(Document.document_id, Condition.condition_number)
             .subquery()
         )
 
@@ -931,7 +929,7 @@ class ConditionService:
                 latest_amendment_subquery,
                 and_(
                     Condition.condition_number == latest_amendment_subquery.c.condition_number,
-                    DocumentCategory.id == latest_amendment_subquery.c.category_id,
+                    Document.document_id == latest_amendment_subquery.c.document_id,
                 ),
             )
             .filter(filter_condition)


### PR DESCRIPTION
Fix: Year Issued shows latest amendment year in consolidated conditions

Previously, "Year Condition Issued" was always derived from the original document's date_issued. For conditions amended multiple times, this showed the wrong year.

Changes:
- Added latest_amendment_subquery to find MAX(Amendment.date_issued) per condition number
- year_issued now uses the latest amendment date, falling back to the document date if no amendments exist
- Applies to both the consolidated conditions table and PDF export