### PR TITLE
CR-156:Export consolidated conditions as PDF

### DIFF
--- a/condition-api/src/condition_api/services/condition_service.py
+++ b/condition-api/src/condition_api/services/condition_service.py
@@ -856,13 +856,15 @@ class ConditionService:
         )
 
         if user_is_internal:
-            amendment_subquery = (
+            ranked_amendments = (
                 db.session.query(
-                    DocumentCategory.id,
-                    Condition.condition_number,
-                    func.string_agg(
-                        Amendment.amendment_name.distinct(), ', '
-                    ).label('amendment_names'),
+                    DocumentCategory.id.label('category_id'),
+                    Condition.condition_number.label('condition_number'),
+                    Amendment.amendment_name.label('amendment_name'),
+                    func.row_number().over(
+                        partition_by=[DocumentCategory.id, Condition.condition_number],
+                        order_by=Amendment.date_issued.desc()
+                    ).label('rn')
                 )
                 .select_from(Project)
                 .join(Document, Document.project_id == Project.project_id)
@@ -872,7 +874,15 @@ class ConditionService:
                 .join(Condition, Condition.amended_document_id == Amendment.amended_document_id)
                 .filter(filter_condition)
                 .filter(Condition.condition_type == ConditionType.AMEND)
-                .group_by(DocumentCategory.id, Condition.condition_number)
+                .subquery()
+            )
+            amendment_subquery = (
+                db.session.query(
+                    ranked_amendments.c.category_id.label('id'),
+                    ranked_amendments.c.condition_number,
+                    ranked_amendments.c.amendment_name.label('amendment_names'),
+                )
+                .filter(ranked_amendments.c.rn == 1)
                 .subquery()
             )
 

--- a/condition-api/src/condition_api/templates/consolidated_conditions.html
+++ b/condition-api/src/condition_api/templates/consolidated_conditions.html
@@ -125,7 +125,7 @@
     .stats-label {
       font-weight: bold;
       color: #0a0a0a;
-      min-width: 50mm;
+      min-width: 60mm;
       flex-shrink: 0;
     }
 
@@ -198,6 +198,7 @@
       margin-right: 1.5mm;
       white-space: nowrap;
       flex-shrink: 0;
+      min-width: 40mm;
     }
 
     .metadata-value {


### PR DESCRIPTION
Summary
- Fix label/value text overlap in the PDF export for "Included Amendments" and "Source Document" fields by applying proper min-width constraints on label elements
- The "Amended Version" badge now displays only the most recent amendment (by date_issued) instead of a comma-separated list of all amendments