### PR TITLE
CR-171:Breadcrumb not linking properly after creating amended condition

### DIFF
--- a/condition-web/src/routes/_authenticated/_dashboard/conditions/project/$projectId/document/$documentId/condition/$conditionId/index.tsx
+++ b/condition-web/src/routes/_authenticated/_dashboard/conditions/project/$projectId/document/$documentId/condition/$conditionId/index.tsx
@@ -52,7 +52,7 @@ function ConditionPage() {
           { title: "Home", path: "/projects", clickable: true },
           { title: conditionDetails?.project_name || "", path: `/projects/${projectId}`, clickable: true },
           { title: conditionDetails?.document_category || "", path: `/documents/project/${projectId}/document-category/${conditionDetails.document_category_id}/`, clickable: true },
-          { title: conditionDetails?.document_label || "", path: undefined, clickable: false },
+          { title: conditionDetails?.document_label || "", path: `/conditions/project/${projectId}/document/${documentId}/`, clickable: true },
           { title: conditionDetails?.condition.condition_name || "", path: undefined, clickable: false }
         ]);
       }


### PR DESCRIPTION
Summary
Fix missing breadcrumb link for document level
- Makes the document label (e.g. "Amendment 3") in the condition detail breadcrumb a clickable link, navigating back to the document's condition list.
