### PR TITLE
CR-171:Breadcrumb not linking properly after creating amended condition

### DIFF
--- a/condition-web/src/routes/_authenticated/_dashboard/projects/$projectId/index.tsx
+++ b/condition-web/src/routes/_authenticated/_dashboard/projects/$projectId/index.tsx
@@ -5,7 +5,7 @@ import { useGetDocumentType } from "@/hooks/api/useDocuments";
 import { useGetProjects } from "@/hooks/api/useProjects";
 import { Else, If, Then } from "react-if";
 import { Projects, ProjectsSkeleton } from "@/components/Projects";
-import { useEffect } from "react";
+import { useEffect, useLayoutEffect } from "react";
 import { notify } from "@/components/Shared/Snackbar/snackbarStore";
 import { PageGrid } from "@/components/Shared/PageGrid";
 import { HTTP_STATUS_CODES } from "../../../../../hooks/api/constants";
@@ -22,7 +22,11 @@ export const Route = createFileRoute("/_authenticated/_dashboard/projects/$proje
 
 export function ProjectsPage() {
   const { projectId } = useParams({ strict: false });
-  const { replaceBreadcrumb, breadcrumbs } = useBreadCrumb();
+  const { replaceBreadcrumb, breadcrumbs, setIsFromConsolidated } = useBreadCrumb();
+
+  useLayoutEffect(() => {
+    setIsFromConsolidated(false);
+  }, [setIsFromConsolidated]);
   const {
     data: projectsData,
     isPending: isProjectsLoading,


### PR DESCRIPTION
Fix breadcrumb not updating when navigating back to project page from condition detail

When navigating to the project page via the breadcrumb from a condition detail view, the breadcrumb would remain stale (still showing all 4 items) instead of resetting to Home / Project Name. This happened because the condition detail page sets isFromConsolidated = true and the project page never reset it, causing BreadcrumbNav to skip route-meta-based breadcrumb rebuilding. Added a useLayoutEffect to reset isFromConsolidated on project page mount.