### PR TITLE
Fix extractor breadcrumb navigation and CI lint issues

### DIFF
--- a/.github/workflows/condition-cron-cd.yml
+++ b/.github/workflows/condition-cron-cd.yml
@@ -1,0 +1,62 @@
+name: CONDITION CRON CD
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "condition-cron/**"
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Environment (dev/test/prod)"
+        required: true
+        default: "dev"
+
+defaults:
+  run:
+    shell: bash
+    working-directory: ./condition-cron
+
+env:
+  APP_NAME: "condition-cron"
+
+jobs:
+  condition-cron-cd:
+    runs-on: ubuntu-22.04
+
+    if: github.repository == 'bcgov/EPIC.conditions'
+    environment:
+      name: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.environment || 'dev' }}
+    env:
+      TAG_NAME: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.environment || 'dev' }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Login Openshift
+        shell: bash
+        run: |
+          oc login --server=${{ secrets.OPENSHIFT_LOGIN_REGISTRY }} --token=${{ secrets.OPENSHIFT_SA_TOKEN }}
+
+      - name: Login Docker
+        run: |
+          echo "${{ secrets.OPENSHIFT_SA_TOKEN }}" |
+          docker login ${{ secrets.OPENSHIFT_IMAGE_REGISTRY }} -u ${{ secrets.OPENSHIFT_SA_NAME }} --password-stdin
+
+      - name: Build image
+        run: |
+          docker build . --file Dockerfile --tag image
+
+      - name: Push image
+        run: |
+          IMAGE_ID=${{ secrets.OPENSHIFT_IMAGE_REGISTRY }}/"${{ secrets.OPENSHIFT_REPOSITORY }}-tools"/$APP_NAME
+          docker tag image $IMAGE_ID:latest
+          docker push $IMAGE_ID:latest
+          docker image tag $IMAGE_ID:latest $IMAGE_ID:$TAG_NAME
+          docker push $IMAGE_ID:$TAG_NAME
+
+      - name: Rollout
+        shell: bash
+        run: |
+          oc rollout restart deployment/${{ env.APP_NAME }} -n ${{ secrets.OPENSHIFT_REPOSITORY }}-${{ env.TAG_NAME }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,8 +33,11 @@ jobs:
           CURRENT_DATE=$(date +"%d_%m_%Y")
           oc tag condition-api:${{ github.event.inputs.environment }} condition-api:${{ github.event.inputs.environment }}_bkp_${CURRENT_DATE}
           oc tag condition-web:${{ github.event.inputs.environment }} condition-web:${{ github.event.inputs.environment }}_bkp_${CURRENT_DATE}
+          oc tag condition-cron:${{ github.event.inputs.environment }} condition-cron:${{ github.event.inputs.environment }}_bkp_${CURRENT_DATE}
           oc tag condition-api:latest condition-api:${{ github.event.inputs.environment }}
           oc tag condition-web:latest condition-web:${{ github.event.inputs.environment }}
+          oc tag condition-cron:latest condition-cron:${{ github.event.inputs.environment }}
           
           oc rollout restart deployment/condition-api -n ${{ secrets.OPENSHIFT_REPOSITORY }}-${{ github.event.inputs.environment }}
           oc rollout restart deployment/condition-web -n ${{ secrets.OPENSHIFT_REPOSITORY }}-${{ github.event.inputs.environment }}
+          oc rollout restart deployment/condition-cron -n ${{ secrets.OPENSHIFT_REPOSITORY }}-${{ github.event.inputs.environment }}

--- a/condition-api/src/condition_api/resources/extraction_request.py
+++ b/condition-api/src/condition_api/resources/extraction_request.py
@@ -52,6 +52,7 @@ class ExtractionRequestsResource(Resource):
         except ValidationError as err:
             return {"message": str(err)}, HTTPStatus.BAD_REQUEST
 
+
 @cors_preflight("PATCH, POST, OPTIONS")
 @API.route("/<int:request_id>/<string:action>", methods=["PATCH", "POST", "OPTIONS"])
 class ExtractionRequestActionResource(Resource):

--- a/condition-api/src/condition_api/services/extraction_import_service.py
+++ b/condition-api/src/condition_api/services/extraction_import_service.py
@@ -32,6 +32,7 @@ class ExtractionImportService:
     """Import extracted JSON into condition tables using SQLAlchemy models."""
 
     def __init__(self, project_id: str, document_id: str, payload: dict[str, Any]):
+        """Initialize the importer for a specific project/document target."""
         self.project_id = project_id
         self.document_id = document_id
         self.payload = payload or {}

--- a/condition-api/src/condition_api/services/extraction_request_service.py
+++ b/condition-api/src/condition_api/services/extraction_request_service.py
@@ -102,7 +102,7 @@ class ExtractionRequestService:
                     document.is_active = True
 
             db.session.commit()
-        except Exception:
+        except (SQLAlchemyError, ValueError, TypeError):
             db.session.rollback()
             raise
         return req

--- a/condition-web/src/components/Documents/DocumentEntryForm.tsx
+++ b/condition-web/src/components/Documents/DocumentEntryForm.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import dayjs from "dayjs";
+import { Dayjs } from "dayjs";
 import {
     Autocomplete,
     Box,
@@ -61,16 +62,12 @@ export const DocumentEntryForm = ({
         selectedDocumentLabel: null as string | null,
         documentLabel: "",
         documentLink: "",
-        dateIssued: null as any,
+        dateIssued: null as Dayjs | null,
         isLatestAmendment: false,
     });
 
     const [errors, setErrors] = useState<Record<string, boolean>>({});
     const [loading, setLoading] = useState(false);
-
-    const updateFormState = (updates: Partial<typeof formState>) => {
-        setFormState((prev) => ({ ...prev, ...updates }));
-    };
 
     useEffect(() => {
         if (!transferData) return;
@@ -78,20 +75,18 @@ export const DocumentEntryForm = ({
             (project) => project.project_id === transferData.projectId
         ) || preselectedProject;
 
-        updateFormState({
+        setFormState((prev) => ({
+            ...prev,
             selectedProject: transferredProject || null,
             selectedDocumentType: transferData.documentTypeId || null,
             documentLabel: transferData.documentLabel || "",
             dateIssued: transferData.dateIssued ? dayjs(transferData.dateIssued) : null,
-        });
-    }, [
-        projectArray,
-        preselectedProject,
-        transferData?.dateIssued,
-        transferData?.documentLabel,
-        transferData?.documentTypeId,
-        transferData?.projectId,
-    ]);
+        }));
+    }, [projectArray, preselectedProject, transferData]);
+
+    const updateFormState = (updates: Partial<typeof formState>) => {
+        setFormState((prev) => ({ ...prev, ...updates }));
+    };
 
     const resetErrors = () => {
         setErrors({

--- a/condition-web/src/components/ExtractedDocuments/ExtractedDocumentsPage.tsx
+++ b/condition-web/src/components/ExtractedDocuments/ExtractedDocumentsPage.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { AxiosError } from "axios";
 import {
   Box,
   Button,
@@ -126,6 +127,13 @@ export default function ExtractedDocumentsPage() {
     replaceBreadcrumb("Extracted Documents", "Extracted Documents", "/extracted-documents", true);
   }, [replaceBreadcrumb]);
 
+  const getErrorMessage = (error: unknown, fallback: string) => {
+    if (error instanceof AxiosError) {
+      return error.response?.data?.message ?? fallback;
+    }
+    return fallback;
+  };
+
   // Only toast once when the query fails, not on every render.
   useEffect(() => {
     if (error) notify.error("Failed to load extraction requests");
@@ -137,8 +145,8 @@ export default function ExtractedDocumentsPage() {
         notify.success("Conditions imported successfully!");
         setPreviewRequest(null);
       },
-      onError: (err: any) =>
-        notify.error(err?.response?.data?.message || "Failed to import conditions"),
+      onError: (error: unknown) =>
+        notify.error(getErrorMessage(error, "Failed to import conditions")),
     });
   };
 
@@ -149,8 +157,8 @@ export default function ExtractedDocumentsPage() {
         setPreviewRequest(null);
         setStopRequest(null);
       },
-      onError: (err: any) =>
-        notify.error(err?.response?.data?.message || "Failed to reject extraction"),
+      onError: (error: unknown) =>
+        notify.error(getErrorMessage(error, "Failed to reject extraction")),
     });
   };
 

--- a/condition-web/src/components/ExtractedDocuments/ExtractionPreviewModal.tsx
+++ b/condition-web/src/components/ExtractedDocuments/ExtractionPreviewModal.tsx
@@ -17,7 +17,7 @@ import {
   Typography,
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
-import { ExtractionRequest } from "@/hooks/api/useExtractionRequests";
+import { ExtractedCondition, ExtractionRequest } from "@/hooks/api/useExtractionRequests";
 
 // ---------- Design tokens --------------------------------------------------
 const colors = {
@@ -115,7 +115,7 @@ export const ExtractionPreviewModal: React.FC<ExtractionPreviewModalProps> = ({
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {conditions.map((cond: any, index: number) => (
+                  {conditions.map((cond: ExtractedCondition, index: number) => (
                     <TableRow key={cond.condition_number ?? index} hover>
                       <TableCell sx={{ color: colors.conditionNumber, fontWeight: "bold" }}>
                         {cond.condition_number ?? index + 1}

--- a/condition-web/src/components/Shared/layout/Header/EAOAppBar.tsx
+++ b/condition-web/src/components/Shared/layout/Header/EAOAppBar.tsx
@@ -5,9 +5,11 @@ import AppBarActions from "./AppBarActions";
 import { useIsMobile } from "@/hooks/common";
 import MobileNav from "./MobileNav";
 import { BCDesignTokens } from "epic.theme";
+import { useNavigate } from "@tanstack/react-router";
 
 export default function EAOAppBar() {
   const isMobile = useIsMobile();
+  const navigate = useNavigate();
   return (
     <>
       <AppBar
@@ -25,7 +27,13 @@ export default function EAOAppBar() {
           justifyContent="space-between"
         >
           <Grid item display="flex" justifyContent="start" alignItems="center">
-            <img src={EAO_Logo} height={isMobile ? 40 : 56} />
+            <img
+              src={EAO_Logo}
+              height={isMobile ? 40 : 56}
+              alt="EAO Logo"
+              style={{ cursor: "pointer" }}
+              onClick={() => navigate({ to: "/projects" })}
+            />
             {!isMobile && (
               <>
                 <Divider orientation="vertical" flexItem sx={{ m: 1 }} />

--- a/condition-web/src/hooks/api/useExtractionRequests.ts
+++ b/condition-web/src/hooks/api/useExtractionRequests.ts
@@ -1,6 +1,17 @@
 import { submitRequest } from "@/utils/axiosUtils";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
+export interface ExtractedCondition {
+    condition_number?: number | null;
+    condition_name?: string | null;
+    topic_tags?: string[] | null;
+}
+
+export interface ExtractedData {
+    conditions?: ExtractedCondition[];
+    [key: string]: unknown;
+}
+
 export interface ExtractionRequest {
     id: number;
     project_id: string;
@@ -12,7 +23,7 @@ export interface ExtractionRequest {
     file_size_bytes?: number | null;
     status: string;
     error_message?: string | null;
-    extracted_data?: Record<string, any>;
+    extracted_data?: ExtractedData | null;
     created_date: string;
     updated_date?: string | null;
 }

--- a/condition-web/src/routes/_authenticated/_dashboard/extracted-documents/index.tsx
+++ b/condition-web/src/routes/_authenticated/_dashboard/extracted-documents/index.tsx
@@ -5,4 +5,8 @@ export const Route = createFileRoute(
   "/_authenticated/_dashboard/extracted-documents/"
 )({
   component: ExtractedDocumentsPage,
+  meta: () => [
+    { title: "Home", path: "/projects" },
+    { title: "Extracted Documents", path: "/extracted-documents" },
+  ],
 });

--- a/condition-web/src/routes/_authenticated/documents/extract/index.tsx
+++ b/condition-web/src/routes/_authenticated/documents/extract/index.tsx
@@ -7,6 +7,7 @@ import { PageGrid } from "@/components/Shared/PageGrid";
 import { DocumentEntryPage } from "@/components/Documents/DocumentEntryPage";
 import { notify } from "@/components/Shared/Snackbar/snackbarStore";
 import { useBreadCrumb } from "@/components/Shared/layout/SideNav/breadCrumbStore";
+import BreadcrumbNav from "@/components/Shared/layout/SideNav/BreadcrumbNav";
 
 export const Route = createFileRoute(
     "/_authenticated/documents/extract/"
@@ -25,7 +26,7 @@ export const Route = createFileRoute(
     }),
     meta: () => [
         { title: "Home", path: "/projects" },
-        { title: "Add/Extract Document", path: "/documents/extract/" },
+        { title: "Add/Extract Document", path: "/documents/extract" },
     ],
 });
 
@@ -48,14 +49,17 @@ export function DocumentExtractPage() {
     }, [isProjectsError]);
 
     return (
-        <PageGrid>
-            <Grid item xs={12}>
-                <DocumentEntryPage
-                    projects={projectsData ?? []}
-                    documentType={documentTypeData ?? []}
-                    manualEntrySearch={manualEntrySearch}
-                />
-            </Grid>
-        </PageGrid>
+        <>
+            <BreadcrumbNav />
+            <PageGrid>
+                <Grid item xs={12}>
+                    <DocumentEntryPage
+                        projects={projectsData ?? []}
+                        documentType={documentTypeData ?? []}
+                        manualEntrySearch={manualEntrySearch}
+                    />
+                </Grid>
+            </PageGrid>
+        </>
     );
 }

--- a/deployment/charts/condition-cron-bc/.helmignore
+++ b/deployment/charts/condition-cron-bc/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deployment/charts/condition-cron-bc/Chart.yaml
+++ b/deployment/charts/condition-cron-bc/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: condition-cron-bc
+description: Build config for condition-cron
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/deployment/charts/condition-cron-bc/README.md
+++ b/deployment/charts/condition-cron-bc/README.md
@@ -1,0 +1,29 @@
+# condition-cron build config Helm chart
+
+Creates the OpenShift image stream and build config for `condition-cron`.
+
+## Lint
+
+```bash
+helm lint deployment/charts/condition-cron-bc
+```
+
+## Render templates
+
+```bash
+helm template condition-cron-bc deployment/charts/condition-cron-bc
+```
+
+## Install
+
+```bash
+helm install condition-cron-bc deployment/charts/condition-cron-bc \
+  --namespace <tools-namespace>
+```
+
+## Upgrade
+
+```bash
+helm upgrade condition-cron-bc deployment/charts/condition-cron-bc \
+  --namespace <tools-namespace>
+```

--- a/deployment/charts/condition-cron-bc/templates/_helpers.tpl
+++ b/deployment/charts/condition-cron-bc/templates/_helpers.tpl
@@ -1,0 +1,60 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "condition-cron-bc.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "condition-cron-bc.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "condition-cron-bc.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "condition-cron-bc.labels" -}}
+helm.sh/chart: {{ include "condition-cron-bc.chart" . }}
+{{ include "condition-cron-bc.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "condition-cron-bc.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "condition-cron-bc.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "condition-cron-bc.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "condition-cron-bc.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deployment/charts/condition-cron-bc/templates/buildconfig.yaml
+++ b/deployment/charts/condition-cron-bc/templates/buildconfig.yaml
@@ -1,0 +1,28 @@
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: {{ .Values.app }}
+  labels:
+    app: {{ .Values.app }}
+spec:
+  nodeSelector: null
+  output:
+    to:
+      kind: ImageStreamTag
+      name: '{{ .Values.app }}:latest'
+  successfulBuildsHistoryLimit: 5
+  failedBuildsHistoryLimit: 5
+  strategy:
+    type: Docker
+    dockerStrategy:
+      dockerfilePath: Dockerfile
+  postCommit: {}
+  source:
+    type: Git
+    git:
+      uri: {{ .Values.githubRepo }}
+      ref: main
+      contextDir: {{ .Values.githubContextDir }}
+  triggers:
+    - type: ConfigChange
+runPolicy: Serial

--- a/deployment/charts/condition-cron-bc/templates/imagestream.yaml
+++ b/deployment/charts/condition-cron-bc/templates/imagestream.yaml
@@ -1,0 +1,7 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: {{ .Values.app }}
+spec:
+  lookupPolicy:
+    local: false

--- a/deployment/charts/condition-cron-bc/values.yaml
+++ b/deployment/charts/condition-cron-bc/values.yaml
@@ -1,0 +1,10 @@
+app: condition-cron
+githubRepo: https://github.com/bcgov/EPIC.conditions.git
+githubContextDir: /condition-cron
+resources:
+  limits:
+    cpu: 1500m
+    memory: 4Gi
+  requests:
+    cpu: 500m
+    memory: 2Gi

--- a/deployment/charts/condition-cron/.helmignore
+++ b/deployment/charts/condition-cron/.helmignore
@@ -1,0 +1,24 @@
+# Patterns to ignore when building packages.
+.DS_Store
+
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deployment/charts/condition-cron/Chart.yaml
+++ b/deployment/charts/condition-cron/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: condition-cron
+description: A Helm chart for deploying the Condition Cron job
+type: application
+version: 0.1.0
+appVersion: "1.0"

--- a/deployment/charts/condition-cron/README.md
+++ b/deployment/charts/condition-cron/README.md
@@ -1,0 +1,40 @@
+# condition-cron Helm chart
+
+Deploys the `condition-cron` worker.
+
+## Lint
+
+```bash
+helm lint deployment/charts/condition-cron
+```
+
+## Render templates
+
+```bash
+helm template condition-cron deployment/charts/condition-cron
+```
+
+## Install
+
+```bash
+helm install condition-cron deployment/charts/condition-cron \
+  --namespace <namespace> \
+  --set imageTag=<tag> \
+  --set s3.bucket=<bucket> \
+  --set s3.host=<host> \
+  --set extractor.apiUrl=<extractor-url> \
+  --set secrets.s3AccessKeyId=<access-key> \
+  --set secrets.s3SecretAccessKey=<secret-key> \
+  --set secrets.extractorApiKey=<api-key>
+```
+
+## Upgrade
+
+```bash
+helm upgrade condition-cron deployment/charts/condition-cron \
+  --namespace <namespace> \
+  --reuse-values \
+  --set imageTag=<tag>
+```
+
+Database credentials are read from the `condition-patroni` secret by default.

--- a/deployment/charts/condition-cron/templates/_helpers.tpl
+++ b/deployment/charts/condition-cron/templates/_helpers.tpl
@@ -1,0 +1,5 @@
+{{- define "condition-cron.labels" -}}
+app: {{ .Values.name }}
+app-group: condition-app
+template: {{ .Values.name }}-deploy
+{{- end -}}

--- a/deployment/charts/condition-cron/templates/configmap.yaml
+++ b/deployment/charts/condition-cron/templates/configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.name }}-config
+  labels:
+{{ include "condition-cron.labels" . | indent 4 }}
+data:
+  crontab: |-
+{{ .Values.cronTab | indent 4 }}
+  FLASK_ENV: "{{ .Values.flask.env }}"
+  DATABASE_HOST: "{{ .Values.database.host }}"
+  DATABASE_PORT: "{{ .Values.database.port }}"
+  S3_BUCKET: "{{ .Values.s3.bucket }}"
+  S3_HOST: "{{ .Values.s3.host }}"
+  S3_REGION: "{{ .Values.s3.region }}"
+  S3_SERVICE: "{{ .Values.s3.service }}"
+  EXTRACTOR_API_URL: "{{ .Values.extractor.apiUrl }}"

--- a/deployment/charts/condition-cron/templates/deployment.yaml
+++ b/deployment/charts/condition-cron/templates/deployment.yaml
@@ -1,0 +1,126 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.name }}
+  labels:
+{{ include "condition-cron.labels" . | indent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Values.name }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.name }}
+        app-group: condition-app
+        environment: {{ .Values.env }}
+    spec:
+      containers:
+        - name: {{ .Values.name }}
+          image: image-registry.openshift-image-registry.svc:5000/{{ .Values.imageNamespace }}/{{ .Values.name }}:{{ .Values.imageTag }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          volumeMounts:
+            - name: cron-config
+              readOnly: true
+              mountPath: /condition-cron/cron/
+          env:
+            - name: FLASK_ENV
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.name }}-config
+                  key: FLASK_ENV
+            - name: DATABASE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.secret }}
+                  key: app-db-username
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.secret }}
+                  key: app-db-password
+            - name: DATABASE_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.secret }}
+                  key: app-db-name
+            - name: DATABASE_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.name }}-config
+                  key: DATABASE_HOST
+            - name: DATABASE_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.name }}-config
+                  key: DATABASE_PORT
+            - name: S3_BUCKET
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.name }}-config
+                  key: S3_BUCKET
+            - name: S3_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.name }}
+                  key: S3_ACCESS_KEY_ID
+            - name: S3_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.name }}
+                  key: S3_SECRET_ACCESS_KEY
+            - name: S3_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.name }}-config
+                  key: S3_HOST
+            - name: S3_REGION
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.name }}-config
+                  key: S3_REGION
+            - name: S3_SERVICE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.name }}-config
+                  key: S3_SERVICE
+            - name: EXTRACTOR_API_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.name }}-config
+                  key: EXTRACTOR_API_URL
+            - name: EXTRACTOR_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.name }}
+                  key: EXTRACTOR_API_KEY
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.name }}
+                  key: OPENAI_API_KEY
+          resources:
+            requests:
+              cpu: {{ .Values.resources.requests.cpu }}
+              memory: {{ .Values.resources.requests.memory }}
+            limits:
+              cpu: {{ .Values.resources.limits.cpu }}
+              memory: {{ .Values.resources.limits.memory }}
+          terminationMessagePath: "/dev/termination-log"
+          terminationMessagePolicy: File
+      volumes:
+        - name: cron-config
+          configMap:
+            name: {{ .Values.name }}-config
+            defaultMode: 420
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+      schedulerName: default-scheduler

--- a/deployment/charts/condition-cron/templates/secret.yaml
+++ b/deployment/charts/condition-cron/templates/secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.name }}
+  labels:
+{{ include "condition-cron.labels" . | indent 4 }}
+type: Opaque
+data:
+  S3_ACCESS_KEY_ID: {{ .Values.secrets.s3AccessKeyId | b64enc | quote }}
+  S3_SECRET_ACCESS_KEY: {{ .Values.secrets.s3SecretAccessKey | b64enc | quote }}
+  EXTRACTOR_API_KEY: {{ .Values.secrets.extractorApiKey | b64enc | quote }}
+  OPENAI_API_KEY: {{ .Values.secrets.openaiApiKey | b64enc | quote }}

--- a/deployment/charts/condition-cron/values.yaml
+++ b/deployment/charts/condition-cron/values.yaml
@@ -1,0 +1,40 @@
+name: condition-cron
+imageNamespace: c8b80a-tools
+env: dev
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 1Gi
+replicaCount: 1
+imageTag: dev
+imagePullPolicy: Always
+
+cronTab: |
+  # PROCESS_DOCUMENTS - runs every 30 minutes
+  */30 * * * * default cd /condition-cron && ./run_process_documents.sh
+
+flask:
+  env: production
+
+database:
+  secret: condition-patroni
+  host: condition-patroni
+  port: "5432"
+
+s3:
+  bucket: ""
+  host: ""
+  region: "us-east-1"
+  service: "s3"
+
+extractor:
+  apiUrl: ""
+
+secrets:
+  s3AccessKeyId: ""
+  s3SecretAccessKey: ""
+  extractorApiKey: ""
+  openaiApiKey: ""


### PR DESCRIPTION
## Summary
- fix breadcrumb rendering/navigation on the extractor pages
- make the header logo navigate back to the projects page
- clean up the related frontend/backend lint issues needed for CI

## Verification
- cd condition-web && npm run lint
- cd condition-web && npm run build
- cd condition-api && venv/bin/flake8 --extend-ignore=Q000,D400,D401,I005,W503 src/condition_api tests

## Notes
- left unrelated local condition-cron and DocumentExtractionForm.tsx changes out of this PR
- backend pytest was not fully runnable in this local environment because the test DB on localhost:54373 was not reachable