### PR TITLE
CR-162:New roles and groups for condition repo

### DIFF
--- a/condition-api/src/condition_api/resources/amendment.py
+++ b/condition-api/src/condition_api/resources/amendment.py
@@ -47,7 +47,7 @@ class AmendmentsResource(Resource):
     @ApiHelper.swagger_decorators(API, endpoint_description="Create new amendments")
     @API.response(code=HTTPStatus.OK, model=amendment_model, description="Create amendments")
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value])
+    @auth.has_one_of_roles([EpicConditionRole.MANAGE_CONDITIONS.value])
     @cross_origin(origins=allowedorigins())
     def post(document_id):
         """Create a new amendment."""

--- a/condition-api/src/condition_api/resources/attribute_key.py
+++ b/condition-api/src/condition_api/resources/attribute_key.py
@@ -48,7 +48,7 @@ class AttributeKeyResource(Resource):
     @ApiHelper.swagger_decorators(API, endpoint_description="Get attribute keys")
     @API.response(code=HTTPStatus.CREATED, model=attributes_model, description="Get attribute keys")
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value])
+    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value, EpicConditionRole.MANAGE_CONDITIONS.value])
     @cross_origin(origins=allowedorigins())
     def get(condition_id):
         """Fetch attribute keys."""

--- a/condition-api/src/condition_api/resources/condition.py
+++ b/condition-api/src/condition_api/resources/condition.py
@@ -52,7 +52,7 @@ class ConditionDetailsResource(Resource):
     @ApiHelper.swagger_decorators(API, endpoint_description="Get conditions by project id")
     @API.response(code=HTTPStatus.CREATED, model=condition_model, description="Get conditions")
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value])
+    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value, EpicConditionRole.MANAGE_CONDITIONS.value])
     @cross_origin(origins=allowedorigins())
     def get(project_id, document_id, condition_id):
         """Fetch conditions and condition attributes by project ID."""
@@ -83,7 +83,7 @@ class ConditionDetailsPatchResource(Resource):
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
     @cross_origin(origins=allowedorigins())
-    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value])
+    @auth.has_one_of_roles([EpicConditionRole.MANAGE_CONDITIONS.value])
     def patch(condition_id):
         """Edit condition data."""
         try:
@@ -116,7 +116,7 @@ class ConditionDetailResource(Resource):
     @ApiHelper.swagger_decorators(API, endpoint_description="Get conditions by project id and document id")
     @API.response(code=HTTPStatus.CREATED, model=condition_model, description="Get conditions")
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value])
+    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value, EpicConditionRole.MANAGE_CONDITIONS.value])
     @cross_origin(origins=allowedorigins())
     def get(project_id, document_id):
         """Fetch conditions and condition attributes by project ID."""
@@ -140,7 +140,7 @@ class ConditionDetailResource(Resource):
     @ApiHelper.swagger_decorators(API, endpoint_description="Create new condition")
     @API.response(code=HTTPStatus.OK, model=condition_model, description="Create condition")
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value])
+    @auth.has_one_of_roles([EpicConditionRole.MANAGE_CONDITIONS.value])
     @cross_origin(origins=allowedorigins())
     def post(project_id, document_id):
         """Create a new condition."""
@@ -182,7 +182,7 @@ class ConditionResource(Resource):
     @ApiHelper.swagger_decorators(API, endpoint_description="Get conditions by condition id")
     @API.response(code=HTTPStatus.CREATED, model=condition_model, description="Get conditions")
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value])
+    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value, EpicConditionRole.MANAGE_CONDITIONS.value])
     @cross_origin(origins=allowedorigins())
     def get(condition_id):
         """Fetch conditions and condition attributes by condition ID."""
@@ -206,7 +206,7 @@ class ConditionResource(Resource):
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
     @cross_origin(origins=allowedorigins())
-    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value])
+    @auth.has_one_of_roles([EpicConditionRole.MANAGE_CONDITIONS.value])
     def patch(condition_id):
         """Edit condition data."""
         try:
@@ -249,7 +249,7 @@ class ConditionResource(Resource):
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
     @cross_origin(origins=allowedorigins())
-    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value])
+    @auth.has_one_of_roles([EpicConditionRole.MANAGE_CONDITIONS.value])
     def delete(condition_id):
         """Remove condition data."""
         try:

--- a/condition-api/src/condition_api/resources/condition_attribute.py
+++ b/condition-api/src/condition_api/resources/condition_attribute.py
@@ -50,7 +50,7 @@ class ConditionAttributeaResource(Resource):
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
     @cross_origin(origins=allowedorigins())
-    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value])
+    @auth.has_one_of_roles([EpicConditionRole.MANAGE_CONDITIONS.value])
     def patch(condition_id):
         """Edit condition attributes data."""
         try:
@@ -70,7 +70,7 @@ class ConditionAttributeaResource(Resource):
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
     @cross_origin(origins=allowedorigins())
-    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value])
+    @auth.has_one_of_roles([EpicConditionRole.MANAGE_CONDITIONS.value])
     def delete(condition_id):
         """Remove condition attribute data."""
         try:

--- a/condition-api/src/condition_api/resources/document.py
+++ b/condition-api/src/condition_api/resources/document.py
@@ -49,7 +49,7 @@ class DocumentsResource(Resource):
     @ApiHelper.swagger_decorators(API, endpoint_description="Create new documents")
     @API.response(code=HTTPStatus.OK, model=document_model, description="Create documents")
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value])
+    @auth.has_one_of_roles([EpicConditionRole.MANAGE_CONDITIONS.value])
     @cross_origin(origins=allowedorigins())
     def post(project_id):
         """Create a new document."""
@@ -70,7 +70,7 @@ class DocumentsResource(Resource):
     @ApiHelper.swagger_decorators(API, endpoint_description="Get all documents")
     @API.response(code=HTTPStatus.OK, model=document_model, description="Get all documents")
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value])
+    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value, EpicConditionRole.MANAGE_CONDITIONS.value])
     @cross_origin(origins=allowedorigins())
     def get(project_id):
         """Get all documents."""
@@ -95,7 +95,7 @@ class DocumentLabelsResource(Resource):
     @ApiHelper.swagger_decorators(API, endpoint_description="Get document labels for a project")
     @API.response(code=HTTPStatus.OK, description="Get document labels")
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value])
+    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value, EpicConditionRole.MANAGE_CONDITIONS.value])
     @cross_origin(origins=allowedorigins())
     def get(project_id):
         """Fetch document_id and document_label for all documents of a project."""
@@ -115,7 +115,7 @@ class AvailableDocumentsResource(Resource):
     @ApiHelper.swagger_decorators(API, endpoint_description="Get available documents for a project")
     @API.response(code=HTTPStatus.OK, model=document_model, description="Get available documents")
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value])
+    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value, EpicConditionRole.MANAGE_CONDITIONS.value])
     @cross_origin(origins=allowedorigins())
     def get(project_id):
         """Fetch inactive documents for a project that can be added."""
@@ -135,7 +135,7 @@ class ActivateDocumentResource(Resource):
     @ApiHelper.swagger_decorators(API, endpoint_description="Activate a document")
     @API.response(code=HTTPStatus.OK, model=document_model, description="Activate document")
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value])
+    @auth.has_one_of_roles([EpicConditionRole.MANAGE_CONDITIONS.value])
     @cross_origin(origins=allowedorigins())
     def patch(document_id):
         """Activate a document to make it visible."""
@@ -161,7 +161,7 @@ class DocumentTypeResource(Resource):
     @ApiHelper.swagger_decorators(API, endpoint_description="Get all document type")
     @API.response(code=HTTPStatus.OK, model=document_model, description="Get all document type")
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value])
+    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value, EpicConditionRole.MANAGE_CONDITIONS.value])
     @cross_origin(origins=allowedorigins())
     def get():
         """Get all document type."""
@@ -184,7 +184,7 @@ class DocumentResource(Resource):
     @ApiHelper.swagger_decorators(API, endpoint_description="Get document details")
     @API.response(code=HTTPStatus.CREATED, model=document_model, description="Get document details")
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value])
+    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value, EpicConditionRole.MANAGE_CONDITIONS.value])
     @cross_origin(origins=allowedorigins())
     def get(document_id):
         """Fetch document details by document ID."""
@@ -205,7 +205,7 @@ class DocumentResource(Resource):
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
     @cross_origin(origins=allowedorigins())
-    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value])
+    @auth.has_one_of_roles([EpicConditionRole.MANAGE_CONDITIONS.value])
     def patch(document_id):
         """Edit document label."""
         try:

--- a/condition-api/src/condition_api/resources/document_category.py
+++ b/condition-api/src/condition_api/resources/document_category.py
@@ -47,7 +47,7 @@ class DocumentCategoryListResource(Resource):
     @ApiHelper.swagger_decorators(API, endpoint_description="Get all document categories")
     @API.response(code=HTTPStatus.OK, description="Get all document categories")
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value])
+    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value, EpicConditionRole.MANAGE_CONDITIONS.value])
     @cross_origin(origins=allowedorigins())
     def get():
         """Fetch all document categories."""
@@ -67,7 +67,7 @@ class DocumentCategoryResource(Resource):
     @ApiHelper.swagger_decorators(API, endpoint_description="Get all documents for document category")
     @API.response(code=HTTPStatus.OK, model=document_model, description="Get documents")
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value])
+    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value, EpicConditionRole.MANAGE_CONDITIONS.value])
     @cross_origin(origins=allowedorigins())
     def get(project_id, category_id):
         """Fetch all documents for a specific document category."""

--- a/condition-api/src/condition_api/resources/management_plan.py
+++ b/condition-api/src/condition_api/resources/management_plan.py
@@ -50,7 +50,7 @@ class ManagementPlanResource(Resource):
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
     @cross_origin(origins=allowedorigins())
-    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value])
+    @auth.has_one_of_roles([EpicConditionRole.MANAGE_CONDITIONS.value])
     def patch(plan_id):
         """Edit management plan data."""
         try:
@@ -68,7 +68,7 @@ class ManagementPlanResource(Resource):
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
     @cross_origin(origins=allowedorigins())
-    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value])
+    @auth.has_one_of_roles([EpicConditionRole.MANAGE_CONDITIONS.value])
     def delete(plan_id):
         """Remove management plan data."""
         try:

--- a/condition-api/src/condition_api/resources/project.py
+++ b/condition-api/src/condition_api/resources/project.py
@@ -46,7 +46,7 @@ class ProjectsResource(Resource):
     @ApiHelper.swagger_decorators(API, endpoint_description="Get all projects")
     @API.response(code=HTTPStatus.OK, model=projects_model, description="Get projects")
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value])
+    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value, EpicConditionRole.MANAGE_CONDITIONS.value])
     @cross_origin(origins=allowedorigins())
     def get():
         """Fetch projects and related documents."""
@@ -72,7 +72,7 @@ class AllProjectsResource(Resource):
     @ApiHelper.swagger_decorators(API, endpoint_description="Get all projects including inactive")
     @API.response(code=HTTPStatus.OK, model=projects_model, description="Get all projects")
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value])
+    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value, EpicConditionRole.MANAGE_CONDITIONS.value])
     @cross_origin(origins=allowedorigins())
     def get():
         """Fetch all projects including inactive ones."""
@@ -92,7 +92,7 @@ class AvailableProjectsResource(Resource):
     @ApiHelper.swagger_decorators(API, endpoint_description="Get available projects")
     @API.response(code=HTTPStatus.OK, model=projects_model, description="Get available projects")
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value])
+    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value, EpicConditionRole.MANAGE_CONDITIONS.value])
     @cross_origin(origins=allowedorigins())
     def get():
         """Fetch inactive projects that can be added to the condition repo."""
@@ -113,7 +113,7 @@ class ActivateProjectResource(Resource):
     @ApiHelper.swagger_decorators(API, endpoint_description="Activate a project")
     @API.response(code=HTTPStatus.OK, model=projects_model, description="Activate project")
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @auth.has_one_of_roles([EpicConditionRole.VIEW_CONDITIONS.value])
+    @auth.has_one_of_roles([EpicConditionRole.MANAGE_CONDITIONS.value])
     @cross_origin(origins=allowedorigins())
     def patch(project_id):
         """Activate a project to make it visible."""

--- a/condition-api/src/condition_api/utils/roles.py
+++ b/condition-api/src/condition_api/utils/roles.py
@@ -20,3 +20,4 @@ class EpicConditionRole(Enum):
 
     VIEW_CONDITIONS = "view_conditions"
     EXTRACT_CONDITIONS = "extract_conditions"
+    MANAGE_CONDITIONS = "manage_conditions"

--- a/condition-api/tests/utilities/factory_scenarios.py
+++ b/condition-api/tests/utilities/factory_scenarios.py
@@ -45,6 +45,8 @@ class TestJwtClaims(dict, Enum):
         'realm_access': {
             'roles': [
                 EpicConditionRole.VIEW_CONDITIONS.value,
+                EpicConditionRole.MANAGE_CONDITIONS.value,
+                EpicConditionRole.EXTRACT_CONDITIONS.value,
             ]
         },
         'resource_access': {

--- a/condition-web/cypress/utils/testUtils.ts
+++ b/condition-web/cypress/utils/testUtils.ts
@@ -25,7 +25,7 @@ const payload = {
   sub: "test-sub",
   resource_access: {
     [OidcConfig.client_id]: {
-      roles: ["view_conditions", "manage_conditions", "extract_conditions"],
+      roles: ["view_conditions", "manage_conditions"],
     },
   },
 };

--- a/condition-web/cypress/utils/testUtils.ts
+++ b/condition-web/cypress/utils/testUtils.ts
@@ -25,7 +25,7 @@ const payload = {
   sub: "test-sub",
   resource_access: {
     [OidcConfig.client_id]: {
-      roles: ["view_conditions"], // required role
+      roles: ["view_conditions", "manage_conditions", "extract_conditions"],
     },
   },
 };

--- a/condition-web/src/components/ConditionDetails/ConditionAttribute/Independent/ConditionAttributeRow.tsx
+++ b/condition-web/src/components/ConditionDetails/ConditionAttribute/Independent/ConditionAttributeRow.tsx
@@ -15,6 +15,7 @@ import {
   managementRequiredKeys
 } from "../Constants";
 import DynamicFieldRenderer from "../DynamicFieldRenderer";
+import { useHasAllowedRoles, KeycloakRoles } from "@/hooks/useAuthorization";
 
 const StyledTableRow = styled(TableRow)(() => ({}));
 
@@ -62,6 +63,7 @@ const ConditionAttributeRow: React.FC<ConditionAttributeRowProps> = ({
   isConsultationRequired,
   isIEMRequired
 }) => {
+  const canManage = useHasAllowedRoles([KeycloakRoles.MANAGE_CONDITIONS]);
   const { key: conditionKey, value: attributeValue } = conditionAttributeItem;
   const [isEditable, setIsEditable] = useState(false);
   const [editableValue, setEditableValue] = useState(attributeValue ?? "");
@@ -289,7 +291,7 @@ const ConditionAttributeRow: React.FC<ConditionAttributeRowProps> = ({
           <IconButton size="small" disabled sx={{ cursor: "default" }}>
             <RemoveIcon />
           </IconButton>
-        ) : (
+        ) : canManage ? (
           isEditable ? (
             <Button
               variant="contained"
@@ -309,7 +311,7 @@ const ConditionAttributeRow: React.FC<ConditionAttributeRowProps> = ({
               <EditIcon />
             </IconButton>
           )
-        )}
+        ) : null}
       </ConditionAttributeHeadTableCell>
     </PackageTableRow>
   );

--- a/condition-web/src/components/ConditionDetails/ConditionAttribute/Independent/ConditionAttributeTable.tsx
+++ b/condition-web/src/components/ConditionDetails/ConditionAttribute/Independent/ConditionAttributeTable.tsx
@@ -29,6 +29,7 @@ import { useGetAttributes } from "@/hooks/api/useAttributeKey";
 import ErrorMessage from "../ErrorMessage";
 import { ApproveButton } from "../ApproveButton";
 import { validateRequiredAttributes } from "@/utils/attributeValidation";
+import { useHasAllowedRoles, KeycloakRoles } from "@/hooks/useAuthorization";
 
 type ConditionAttributeTableProps = {
     condition: ConditionModel;
@@ -42,6 +43,7 @@ const ConditionAttributeTable = memo(({
     origin
   }: ConditionAttributeTableProps) => {
     const queryClient = useQueryClient();
+    const canManage = useHasAllowedRoles([KeycloakRoles.MANAGE_CONDITIONS]);
     const [conditionAttributeError, setConditionAttributeError] = useState(false);
     const [isAnyRowEditing, setIsAnyRowEditing] = useState(false);
     const [showEditingError, setShowEditingError] = useState(false);
@@ -371,7 +373,7 @@ const ConditionAttributeTable = memo(({
 
         <Stack sx={{ mt: 5 }} direction={"row"}>
           <Box width="50%" sx={{ display: 'flex', justifyContent: 'flex-start' }}>
-            {!condition.is_condition_attributes_approved 
+            {canManage && !condition.is_condition_attributes_approved
              && attributesData && attributesData?.length > 0 && (
               <Button
                 variant="contained"
@@ -408,7 +410,7 @@ const ConditionAttributeTable = memo(({
             />
           }
 
-          {origin !== 'create' && (
+          {canManage && origin !== 'create' && (
             <Box width="50%" sx={{ display: 'flex', justifyContent: 'flex-end' }}>
               <ApproveButton
                 isApproved={condition.is_condition_attributes_approved || false}

--- a/condition-web/src/components/ConditionDetails/ConditionAttribute/ManagementPlan/ManagementPlanAccordion.tsx
+++ b/condition-web/src/components/ConditionDetails/ConditionAttribute/ManagementPlan/ManagementPlanAccordion.tsx
@@ -39,6 +39,7 @@ import { validateRequiredAttributes } from "@/utils/attributeValidation";
 import { useUpdateConditionDetails } from "@/hooks/api/useConditions";
 import DeleteIcon from '@mui/icons-material/Delete';
 import DeleteConfirmationModal from "./DeleteConfirmationModal";
+import { useHasAllowedRoles, KeycloakRoles } from "@/hooks/useAuthorization";
 
 type Props = {
   attributes: ManagementPlanModel;
@@ -56,6 +57,7 @@ const ManagementPlanAccordion: React.FC<Props> = ({
     onDelete
 }) => {
   const queryClient = useQueryClient();
+  const canManage = useHasAllowedRoles([KeycloakRoles.MANAGE_CONDITIONS]);
   const [editMode, setEditMode] = useState(false);
   const [planName, setPlanName] = useState(title);
   const [expanded, setExpanded] = useState(false);
@@ -378,7 +380,7 @@ const ManagementPlanAccordion: React.FC<Props> = ({
                   ) : (
                   <Box display="flex" alignItems="center" gap={1}>
                       <Typography fontWeight="bold">{planName}</Typography>
-                      {expanded && !attributes.is_approved && (
+                      {canManage && expanded && !attributes.is_approved && (
                       <Button
                           variant="contained"
                           size="small"
@@ -418,17 +420,19 @@ const ManagementPlanAccordion: React.FC<Props> = ({
               marginTop="5px"
               alignItems="flex-end"
             >
-              <Tooltip title="Delete Management Plan">
-                <IconButton
-                  onClick={(e) => {
-                    e.stopPropagation(); // Prevent accordion toggle
-                    setIsDeleteModalOpen(true);
-                  }}
-                  size="small"
-                >
-                  <DeleteIcon sx={{ fontSize: '34px' }} />
-                </IconButton>
-              </Tooltip>
+              {canManage && (
+                <Tooltip title="Delete Management Plan">
+                  <IconButton
+                    onClick={(e) => {
+                      e.stopPropagation(); // Prevent accordion toggle
+                      setIsDeleteModalOpen(true);
+                    }}
+                    size="small"
+                  >
+                    <DeleteIcon sx={{ fontSize: '34px' }} />
+                  </IconButton>
+                </Tooltip>
+              )}
             </Box>
         </AccordionSummary>
 
@@ -486,7 +490,7 @@ const ManagementPlanAccordion: React.FC<Props> = ({
           />
 
           <Stack sx={{ mt: 5 }} direction={"row"}>
-            {origin !== 'create' && (
+            {canManage && origin !== 'create' && (
                 <Box width="100%" sx={{ display: 'flex', justifyContent: 'flex-end' }}>
                     <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end' }}>
                         <ApproveButton

--- a/condition-web/src/components/ConditionDetails/ConditionAttribute/ManagementPlan/ManagementPlanSection.tsx
+++ b/condition-web/src/components/ConditionDetails/ConditionAttribute/ManagementPlan/ManagementPlanSection.tsx
@@ -14,6 +14,7 @@ import { useRemoveManagementPlan } from "@/hooks/api/useManagementPlan";
 import { notify } from "@/components/Shared/Snackbar/snackbarStore";
 import { useQueryClient } from "@tanstack/react-query";
 import { QUERY_KEY } from "@/hooks/api/constants";
+import { useHasAllowedRoles, KeycloakRoles } from "@/hooks/useAuthorization";
 
 type ManagementPlanSectionProps = {
     condition: ConditionModel;
@@ -22,6 +23,7 @@ type ManagementPlanSectionProps = {
 
 const ManagementPlanSection = memo(({ condition, setCondition, }: ManagementPlanSectionProps) => {
     const queryClient = useQueryClient();
+    const canManage = useHasAllowedRoles([KeycloakRoles.MANAGE_CONDITIONS]);
 
     const managementPlans = condition?.condition_attributes?.management_plans || [];
 
@@ -112,7 +114,7 @@ const ManagementPlanSection = memo(({ condition, setCondition, }: ManagementPlan
           />
           ))}
 
-          {isUpdating ? (
+          {canManage && (isUpdating ? (
             <CircularProgress size={20} color="inherit" sx={{ mr: 1 }} />
           ) : (
             <Button
@@ -123,7 +125,7 @@ const ManagementPlanSection = memo(({ condition, setCondition, }: ManagementPlan
                 >
                 Add Management Plan
             </Button>
-          )}
+          ))}
       </Box>
     );
 });

--- a/condition-web/src/components/ConditionDetails/ConditionDescription.tsx
+++ b/condition-web/src/components/ConditionDetails/ConditionDescription.tsx
@@ -11,6 +11,7 @@ import { QUERY_KEY } from "@/hooks/api/constants";
 import { BCDesignTokens } from "epic.theme";
 import SubconditionComponent from "./SubCondition";
 import { useSubconditionHandler } from "@/hooks/api/useSubconditionHandler";
+import { useHasAllowedRoles, KeycloakRoles } from "@/hooks/useAuthorization";
 import {
   DragDropContext,
   Droppable,
@@ -48,6 +49,7 @@ const ConditionDescription = memo(({
   setIsLoading
 }: ConditionDescriptionProps) => {
   const queryClient = useQueryClient();
+  const canManage = useHasAllowedRoles([KeycloakRoles.MANAGE_CONDITIONS]);
   const [isEditing, setIsEditing] = useState(editMode);
   const [showEditingError, setShowEditingError] = useState(false);
   const [activeDroppableId, setActiveDroppableId] = useState<string | null>(null);
@@ -225,7 +227,7 @@ const ConditionDescription = memo(({
       </DragDropContext>
       <Stack sx={{ mt: 5 }} direction={"row"}>
         <Box width="50%" sx={{ display: 'flex', justifyContent: 'flex-start' }}>
-          {isEditing && (
+          {canManage && isEditing && (
             <Button
               variant="contained"
               color="secondary"
@@ -244,20 +246,22 @@ const ConditionDescription = memo(({
         </Box>
         <Box width="50%" sx={{ display: 'flex', justifyContent: 'flex-end' }}>
           <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end' }}>
-            <Button
+            {canManage && (
+              <Button
                 variant="contained"
                 color="primary"
                 size="small"
                 sx={{
-                  width: "260px", 
+                  width: "260px",
                   padding: "4px 8px",
                   borderRadius: "4px",
                 }}
                 onClick={approveConditionDescription}
-            >
-              {isConditionApproved ?
-              'Un-approve Condition Requirements' : 'Approve Condition Requirements'}
-            </Button>
+              >
+                {isConditionApproved ?
+                'Un-approve Condition Requirements' : 'Approve Condition Requirements'}
+              </Button>
+            )}
             {showEditingError && isEditing && (
               <Box
                 sx={{

--- a/condition-web/src/components/ConditionDetails/ConditionHeader.tsx
+++ b/condition-web/src/components/ConditionDetails/ConditionHeader.tsx
@@ -12,6 +12,7 @@ import { PartialUpdateTopicTagsModel } from "@/models/Condition";
 import ChipInput from "../Shared/Chips/ChipInput";
 import { HTTP_STATUS_CODES, QUERY_KEY } from "../../hooks/api/constants";
 import { useQueryClient } from "@tanstack/react-query";
+import { useHasAllowedRoles, KeycloakRoles } from "@/hooks/useAuthorization";
 
 type ConditionHeaderProps = {
     conditionId: number;
@@ -29,6 +30,7 @@ const ConditionHeader = ({
     setCondition
 }: ConditionHeaderProps) => {
     const queryClient = useQueryClient();
+    const canManage = useHasAllowedRoles([KeycloakRoles.MANAGE_CONDITIONS]);
     const [editConditionMode, setEditConditionMode] = useState(false);
     const [conditionNumber, setConditionNumber] = useState(condition?.condition_number || "");
     const [conditionName, setConditionName] = useState(condition?.condition_name || "");
@@ -294,7 +296,7 @@ const ConditionHeader = ({
                         </Box>
                       )}
                     </Box>
-                    {!condition.is_topic_tags_approved && !condition.condition_name && (
+                    {canManage && !condition.is_topic_tags_approved && !condition.condition_name && (
                       <Button
                         variant="contained"
                         size="small"
@@ -325,7 +327,7 @@ const ConditionHeader = ({
                         </Typography>
                       </Button>
                     )}
-                    {!condition.is_topic_tags_approved && condition.condition_name && (
+                    {canManage && !condition.is_topic_tags_approved && condition.condition_name && (
                       <Button
                         variant="contained"
                         size="small"
@@ -499,7 +501,7 @@ const ConditionHeader = ({
               </Grid>
             </Box>
 
-            {!condition.is_topic_tags_approved && (
+            {canManage && !condition.is_topic_tags_approved && (
               <Button
                 variant="contained"
                 size="small"
@@ -550,7 +552,7 @@ const ConditionHeader = ({
             paddingBottom={1}
           >
             <Stack direction="row" spacing={1}>
-                {!editMode &&
+                {canManage && !editMode &&
                     <Button
                         variant="contained"
                         color="primary"

--- a/condition-web/src/components/ConditionDetails/ConditionInfoTabs.tsx
+++ b/condition-web/src/components/ConditionDetails/ConditionInfoTabs.tsx
@@ -7,6 +7,7 @@ import { BCDesignTokens } from 'epic.theme';
 import ConditionAttribute from './ConditionAttribute';
 import ConditionDescription from './ConditionDescription';
 import { ConditionModel } from "@/models/Condition";
+import { useHasAllowedRoles, KeycloakRoles } from "@/hooks/useAuthorization";
 
 const StyledTabs = styled(Tabs)({
     transition: 'none',
@@ -59,6 +60,7 @@ const ConditionInfoTabs: React.FC<{
     condition: ConditionModel;
     setCondition: React.Dispatch<React.SetStateAction<ConditionModel>>;
 }> = ({ projectId, documentId, conditionId, condition, setCondition }) => {
+    const canManage = useHasAllowedRoles([KeycloakRoles.MANAGE_CONDITIONS]);
     const [selectedTab, setSelectedTab] = useState('requirements');
     const [editMode, setEditMode] = useState(false);
     const [isConditionApproved, setIsConditionApproved] = useState(condition.is_approved || false);
@@ -91,7 +93,7 @@ const ConditionInfoTabs: React.FC<{
                 </StyledTabs>
 
                 {/* Conditionally render the Edit button only if the "requirements" tab is selected */}
-                {selectedTab === 'requirements' && !isConditionApproved && (
+                {canManage && selectedTab === 'requirements' && !isConditionApproved && (
                     <EditButton
                         variant="contained"
                         size="small"

--- a/condition-web/src/components/Conditions/index.tsx
+++ b/condition-web/src/components/Conditions/index.tsx
@@ -20,6 +20,7 @@ import LoadingButton from "../Shared/Buttons/LoadingButton";
 import ConditionFilters from "@/components/Filters/ConditionFilters";
 import { useConditionFilters } from "@/components/Filters/conditionFilterStore";
 import { CONDITION_STATUS, ConditionStatus } from "@/models/Condition";
+import { useHasAllowedRoles, KeycloakRoles } from "@/hooks/useAuthorization";
 
 export const CardInnerBox = styled(Box)({
   display: "flex",
@@ -52,6 +53,7 @@ export const Conditions = ({
   onDocumentLabelChange
 }: ConditionsParam) => {
   const navigate = useNavigate();
+  const canManage = useHasAllowedRoles([KeycloakRoles.MANAGE_CONDITIONS]);
   const [hasAmendments, setHasAmendments] = useState(false);
   const [isToggleEnabled, setIsToggleEnabled] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
@@ -191,22 +193,24 @@ export const Conditions = ({
                 </Typography>
               </Grid>
               <Grid item xs={6} sx={{ display: "flex", justifyContent: "flex-end" }}>
-                <LoadingButton
-                  variant="contained"
-                  color="primary"
-                  size="small"
-                  startIcon={<AddIcon fontSize="small" />}
-                  sx={{
-                    borderRadius: "4px",
-                    minWidth: "170px",
-                    maxWidth: "200px",
-                    height: "42px",
-                  }}
-                  onClick={() => handleOpenCreateNewCondition()}
-                  loading={loading}
-                >
-                  Add Condition
-                </LoadingButton>
+                {canManage && (
+                  <LoadingButton
+                    variant="contained"
+                    color="primary"
+                    size="small"
+                    startIcon={<AddIcon fontSize="small" />}
+                    sx={{
+                      borderRadius: "4px",
+                      minWidth: "170px",
+                      maxWidth: "200px",
+                      height: "42px",
+                    }}
+                    onClick={() => handleOpenCreateNewCondition()}
+                    loading={loading}
+                  >
+                    Add Condition
+                  </LoadingButton>
+                )}
               </Grid>
             </Grid>
             <Grid container direction="row" px={2} pb={3} wrap="wrap">
@@ -255,47 +259,49 @@ export const Conditions = ({
                 </Typography>
                 )}
               </Grid>
-              <Grid
-                item
-                sx={{
-                  display: "flex",
-                  justifyContent: "flex-start",
-                  border: `1px solid ${BCDesignTokens.surfaceColorBorderDefault}`,
-                  borderLeft: "none",
-                  borderRadius: "0 4px 4px 0",
-                  height: "40px",
-                }}
-              >
-                <Button
-                  variant="contained"
-                  size="small"
-                  onClick={handleEditClick}
+              {canManage && (
+                <Grid
+                  item
                   sx={{
-                    alignSelf: "stretch",
-                    borderRadius: "0 4px 4px 0",
+                    display: "flex",
+                    justifyContent: "flex-start",
                     border: `1px solid ${BCDesignTokens.surfaceColorBorderDefault}`,
-                    backgroundColor: BCDesignTokens.surfaceColorBackgroundLightGray,
-                    height: '100%',
-                    padding: '2.25px 0',
-                    display: 'flex',
-                    alignItems: 'center',
-                    color: "black",
-                    '&:hover': {
-                      backgroundColor: BCDesignTokens.surfaceColorBorderDefault,
-                    },
+                    borderLeft: "none",
+                    borderRadius: "0 4px 4px 0",
+                    height: "40px",
                   }}
                 >
-                  <Typography component="span" sx={{ display: 'inline-flex', alignItems: 'center' }}>
-                    {isEditing ?
-                      <SaveAltIcon sx={{ color: "#255A90", mr: 0.5 }} fontSize="small" /> :
-                      <EditIcon sx={{ color: "#255A90", mr: 0.5 }} fontSize="small" />
-                    }
-                    <Box component="span" sx={{ mr: 1, color: "#255A90", fontWeight: "bold" }}>
-                      {isEditing ? "Save" : "Edit"}
-                    </Box>
-                  </Typography>
-                </Button>
-              </Grid>
+                  <Button
+                    variant="contained"
+                    size="small"
+                    onClick={handleEditClick}
+                    sx={{
+                      alignSelf: "stretch",
+                      borderRadius: "0 4px 4px 0",
+                      border: `1px solid ${BCDesignTokens.surfaceColorBorderDefault}`,
+                      backgroundColor: BCDesignTokens.surfaceColorBackgroundLightGray,
+                      height: '100%',
+                      padding: '2.25px 0',
+                      display: 'flex',
+                      alignItems: 'center',
+                      color: "black",
+                      '&:hover': {
+                        backgroundColor: BCDesignTokens.surfaceColorBorderDefault,
+                      },
+                    }}
+                  >
+                    <Typography component="span" sx={{ display: 'inline-flex', alignItems: 'center' }}>
+                      {isEditing ?
+                        <SaveAltIcon sx={{ color: "#255A90", mr: 0.5 }} fontSize="small" /> :
+                        <EditIcon sx={{ color: "#255A90", mr: 0.5 }} fontSize="small" />
+                      }
+                      <Box component="span" sx={{ mr: 1, color: "#255A90", fontWeight: "bold" }}>
+                        {isEditing ? "Save" : "Edit"}
+                      </Box>
+                    </Typography>
+                  </Button>
+                </Grid>
+              )}
               <Grid item sx={{ display: "flex"}} px={1}>
                 {hasAmendments && (
                   <Box sx={{ display: "flex", justifyContent: 'center', alignItems: "center" }}>

--- a/condition-web/src/components/Documents/index.tsx
+++ b/condition-web/src/components/Documents/index.tsx
@@ -11,6 +11,7 @@ import AddIcon from '@mui/icons-material/Add';
 import LoadingButton from "../Shared/Buttons/LoadingButton";
 import { CreateDocumentModal } from "../Projects/CreateDocumentModal";
 import { ProjectModel } from "@/models/Project";
+import { useHasAllowedRoles, KeycloakRoles } from "@/hooks/useAuthorization";
 
 export const CardInnerBox = styled(Box)({
   display: "flex",
@@ -32,6 +33,7 @@ type DocumentsParam = {
 };
 
 export const Documents = ({ projectName, projectId, categoryId, documentLabel, documents, project, documentType }: DocumentsParam) => {
+  const canManage = useHasAllowedRoles([KeycloakRoles.MANAGE_CONDITIONS]);
   const [isAllApproved, setIsAllApproved] = useState<boolean | null>(false);
   const [openModal, setOpenModal] = useState(false);
   const [isOpeningModal, setIsOpeningModal] = useState(false);
@@ -95,7 +97,7 @@ export const Documents = ({ projectName, projectId, categoryId, documentLabel, d
                   </Box>
                 </Box>
               </Grid>
-              {project && documentType && (
+              {canManage && project && documentType && (
                 <Grid item sx={{ pr: BCDesignTokens.layoutPaddingMedium }}>
                   <LoadingButton
                     variant="contained"

--- a/condition-web/src/components/Projects/index.tsx
+++ b/condition-web/src/components/Projects/index.tsx
@@ -26,6 +26,7 @@ type ProjectsParams = {
 };
 
 export const Projects = ({ projects, documentType }: ProjectsParams) => {
+  const canManage = useHasAllowedRoles([KeycloakRoles.MANAGE_CONDITIONS]);
   const projectArray = projects || [];
   const itemsPerPage = 10; // Number of projects per page
   const [projectSearch, setProjectSearch] = useState("");
@@ -93,25 +94,27 @@ export const Projects = ({ projects, documentType }: ProjectsParams) => {
           <Box sx={{ flexGrow: 1 }} />
 
           {/* Add Document Button */}
-          <LoadingButton
-            variant="contained"
-            color="primary"
-            size="small"
-            sx={{
-              flex: { xs: "auto", sm: "0 0 15%" }, // Auto width, no extra space
-              width: { xs: "100%", sm: "auto" }, // Full width on mobile, auto on large screens
-              height: "70%",
-              borderRadius: "4px",
-              paddingLeft: "2px",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-            }}
-            onClick={handleOpenCreateNewDocument}
-            loading={isOpeningModal}
-          >
-            <AddIcon fontSize="small" /> {hasExtractionRole ? "Add/Extract Document" : "Add Document"}
-          </LoadingButton>
+          {canManage && (
+            <LoadingButton
+              variant="contained"
+              color="primary"
+              size="small"
+              sx={{
+                flex: { xs: "auto", sm: "0 0 15%" },
+                width: { xs: "100%", sm: "auto" },
+                height: "70%",
+                borderRadius: "4px",
+                paddingLeft: "2px",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+              onClick={handleOpenCreateNewDocument}
+              loading={isOpeningModal}
+            >
+              <AddIcon fontSize="small" /> {hasExtractionRole ? "Add/Extract Document" : "Add Document"}
+            </LoadingButton>
+          )}
         </Stack>
       </Grid>
       <Grid item sx={{ width: '100%', marginTop: 1 }} >

--- a/condition-web/src/hooks/useAuthorization.tsx
+++ b/condition-web/src/hooks/useAuthorization.tsx
@@ -6,6 +6,7 @@ import { OidcConfig } from "@/utils/config";
 export const KeycloakRoles = {
   VIEW_CONDITIONS: "view_conditions",
   EXTRACT_CONDITIONS: "extract_conditions",
+  MANAGE_CONDITIONS: "manage_conditions",
 };
 
 // Extend the JWT payload to include optional groups


### PR DESCRIPTION
Changes:

-Add CONDITION-REPO/VIEWER Keycloak group so users assigned to Viewer can access the Condition Extractor via the Centre launch page

-Add manage_users role check to grant user management access in Centre for the Condition Repository

-Fix access level filter to exclude entries with missing name to prevent invalid groups from appearing

-Guard level sort against None values to prevent crash when Keycloak groups have incomplete data
