### PR TITLE
CR-84:Reduce size of the status badges to *20 padding* so it does not  look like a button

### DIFF
--- a/condition-web/src/components/Projects/DocumentStatusChip.tsx
+++ b/condition-web/src/components/Projects/DocumentStatusChip.tsx
@@ -43,8 +43,8 @@ export default function DocumentStatusChip({
   return (
     <Chip
       sx={{
-        width: "160px",
         justifyContent: "center",
+        "& .MuiChip-label": { px: "20px" },
         ...style.sx,
       }}
       label={style.label}


### PR DESCRIPTION
Summary :
Reduce status badge padding to prevent button-like appearance

Changes:
Removed the fixed `width: "160px"` from `DocumentStatusChip` and replaced it with a `20px` horizontal padding on the chip label (`& .MuiChip-label: { px: "20px" }`), so badges size to their content and no longer resemble buttons.


