### PR TITLE
CR-159:UI for condition extractor

### DIFF
--- a/condition-web/src/components/ExtractedDocuments/ExtractedDocumentsPage.tsx
+++ b/condition-web/src/components/ExtractedDocuments/ExtractedDocumentsPage.tsx
@@ -246,7 +246,7 @@ export default function ExtractedDocumentsPage() {
         </DialogTitle>
         <DialogContent dividers>
           <Typography color="error" fontSize="1.1rem">
-            This will stop the extraction process for {stopRequest ? getDocumentName(stopRequest) : "this document"}.
+            This will stop the extraction process for <strong>{stopRequest ? getDocumentName(stopRequest) : "this document"}</strong>.
           </Typography>
           <Typography color="error" fontSize="1.1rem">
             Are you sure you wish to proceed?
@@ -298,7 +298,7 @@ export default function ExtractedDocumentsPage() {
                 textColor={colors.bodyText}
                 chevronColor={colors.bodyText}
               />
-              {sectionsOpen.complete && <Box p={2} display="flex" flexDirection="column" gap={2}>
+              {sectionsOpen.complete && <Box p={2} display="flex" flexDirection="column" gap="15px">
                 {completedRequests.length === 0 ? (
                   <Typography variant="body2" color="textSecondary" sx={{ px: 2 }}>
                     No recent extractions are ready for review.
@@ -358,7 +358,7 @@ export default function ExtractedDocumentsPage() {
                             </Typography>
                             <Typography variant="body2" color="textSecondary" sx={{ fontSize: "0.8rem" }}>
                               {isSuccess
-                                ? `Successfully extracted ${conditionCount} condition${conditionCount !== 1 ? "s" : ""} from ${getDocumentName(req)}.`
+                                ? `Successfully extracted ${conditionCount} condition${conditionCount !== 1 ? "s" : ""}.`
                                 : req.error_message || "Unable to extract conditions. The file may be corrupted, scanned as an image, or in an unsupported format."}
                             </Typography>
                           </Box>
@@ -385,6 +385,7 @@ export default function ExtractedDocumentsPage() {
                             }
                             sx={{
                               textTransform: "none",
+                              whiteSpace: "nowrap",
                               backgroundColor: colors.buttonBg,
                               color: colors.bodyText,
                               borderColor: colors.divider,

--- a/condition-web/src/components/Shared/layout/SideNav/SideNavBar.tsx
+++ b/condition-web/src/components/Shared/layout/SideNav/SideNavBar.tsx
@@ -3,12 +3,11 @@ import { MainListItem } from "./MainListItem";
 
 export default function SideNavBar() {
   return (
-    <div style={{ height: "100%" }}>
+    <div style={{ minHeight: "calc(100vh - 88px)", borderRight: "1px solid #0000001A", width: 240 }}>
       <Box
         sx={{
           overflow: "auto",
-          borderRight: "1px solid #0000001A",
-          width: 240,
+          width: "100%",
           height: "calc(100vh - 88px)",
           zIndex: 0,
           position: "static",


### PR DESCRIPTION
Summary

- Side nav border: Fixed the right border not extending to the bottom of the page when the content scrolls. Moved the border to the outer wrapper div with minHeight: calc(100vh - 88px) so it always spans the full viewport height.
- "Preview & Import Conditions" button: Added whiteSpace: nowrap to prevent the button label from wrapping to a second line.
- Extraction Complete card spacing: Adjusted gap between cards from 16px to 15px.
- Stop extraction dialog: Made the document name bold in the confirmation message for better readability.