### PR TITLE
CR-97:Nesting Amendments under their respective Certificate Doc

### DIFF
--- a/condition-api/src/condition_api/schemas/document.py
+++ b/condition-api/src/condition_api/schemas/document.py
@@ -47,6 +47,7 @@ class DocumentSchema(Schema):
     status = fields.Bool(data_key="status")
     amendment_count = fields.Int(data_key="amendment_count")
     is_latest_amendment_added = fields.Bool(data_key="is_latest_amendment_added")
+    parent_document_id = fields.Str(data_key="parent_document_id", allow_none=True)
     is_active = fields.Bool(data_key="is_active")
     project_name = fields.Str(data_key="project_name")
     type = fields.Str(data_key="type")

--- a/condition-api/src/condition_api/services/document_service.py
+++ b/condition-api/src/condition_api/services/document_service.py
@@ -179,7 +179,8 @@ class DocumentService:
                     'document_label': amendment.document_label,
                     'created_date': amendment.created_date,
                     'year_issued': amendment.year_issued,
-                    'status': amendment.status
+                    'status': amendment.status,
+                    'parent_document_id': document.document_id
                 })
 
         project_name = documents[0].project_name if documents else None

--- a/condition-web/src/components/Documents/DocumentTable.tsx
+++ b/condition-web/src/components/Documents/DocumentTable.tsx
@@ -10,7 +10,20 @@ import {
   import { AllDocumentModel } from "@/models/Document";
   import { StyledTableHeadCell } from "../Shared/Table/common";
   import DocumentTableRow from "./DocumentTableRow";
-  
+
+  interface GroupedDocument {
+    cert: AllDocumentModel;
+    amendments: AllDocumentModel[];
+  }
+
+  function groupDocuments(documents: AllDocumentModel[]): GroupedDocument[] {
+    const certDocs = documents.filter((d) => !d.parent_document_id);
+    return certDocs.map((cert) => ({
+      cert,
+      amendments: documents.filter((d) => d.parent_document_id === cert.document_id),
+    }));
+  }
+
   export default function DocumentTable({
     projectId,
     documents,
@@ -20,6 +33,8 @@ import {
     documents: Array<AllDocumentModel>;
     headless?: boolean;
   }) {
+    const grouped = groupDocuments(documents);
+
     return (
       <TableContainer component={Box} sx={{ height: "100%" }}>
         <Table sx={{ tableLayout: "fixed", border: 0 }} aria-label="simple table">
@@ -46,11 +61,12 @@ import {
             </TableHead>
           )}
           <TableBody>
-            {documents?.map((document) => (
+            {grouped.map(({ cert, amendments }) => (
               <DocumentTableRow
                 projectId={projectId}
-                key={document.document_id}
-                document={document}
+                key={cert.document_id}
+                document={cert}
+                amendments={amendments}
               />
             ))}
           </TableBody>

--- a/condition-web/src/components/Documents/DocumentTableRow.tsx
+++ b/condition-web/src/components/Documents/DocumentTableRow.tsx
@@ -8,81 +8,97 @@ import { useNavigate } from "@tanstack/react-router";
 interface DocumentRowProps {
   projectId: string;
   document: AllDocumentModel;
+  amendments?: AllDocumentModel[];
+  isAmendment?: boolean;
 }
 
 const border = `1px solid ${BCDesignTokens.surfaceColorBorderDefault}`;
 
-export default function DocumentTableRow({ projectId, document }: DocumentRowProps) {
-
+function DocumentRow({ projectId, document, isAmendment }: { projectId: string; document: AllDocumentModel; isAmendment?: boolean }) {
   const navigate = useNavigate();
   const handleOnDocumentClick = () => {
-    if (projectId && projectId) {
-        navigate({
+    if (projectId) {
+      navigate({
         to: `/conditions/project/${projectId}/document/${document.document_id}`,
-        });
+      });
     }
   };
 
   return (
-    <>
-      <TableRow
-        key={`row-${document.document_id}`}
+    <TableRow
+      key={`row-${document.document_id}`}
+      sx={{
+        "&:hover": {
+          backgroundColor: BCDesignTokens.surfaceColorMenusHover,
+        },
+      }}
+    >
+      <TableCell
+        align="left"
         sx={{
-          "&:hover": {
-            backgroundColor: BCDesignTokens.surfaceColorMenusHover,
-          },
+          borderBottom: border,
+          padding: BCDesignTokens.layoutPaddingXsmall,
+          paddingLeft: isAmendment ? 6 : BCDesignTokens.layoutPaddingXsmall,
+          width: '50%',
         }}
       >
-        <TableCell
-          align="left"
+        <Link
           sx={{
-            borderBottom: border,
-            padding: BCDesignTokens.layoutPaddingXsmall,
-            width: '50%', // Ensure width matches header
+            color: BCDesignTokens.themeBlue90,
+            textDecoration: "none",
+            display: "flex",
+            alignItems: "center",
           }}
+          component={"button"}
+          onClick={() => handleOnDocumentClick()}
         >
-          <Link
-            sx={{
-              color: BCDesignTokens.themeBlue90,
-              textDecoration: "none",
-              display: "flex",
-              alignItems: "center",
-            }}
-            component={"button"}
-            onClick={() => handleOnDocumentClick()}
+          <Typography
+            color={BCDesignTokens.themeBlue90}
+            fontWeight={"bold"}
+            fontSize={18}
+            align="left"
           >
-            <Typography
-              color={BCDesignTokens.themeBlue90}
-              fontWeight={"bold"}
-              fontSize={18}
-              align="left"
-            >
-              {document.document_label ?? "--"}
-            </Typography>
-            <ArrowForwardIos fontSize="small" />
-          </Link>
-        </TableCell>
-        <TableCell
-          align="right"
-          sx={{
-            borderBottom: border,
-            padding: BCDesignTokens.layoutPaddingXsmall,
-            width: '25%', // Ensure width matches header
-          }}
-        >
-          {document.year_issued ?? "--"}
-        </TableCell>
-        <TableCell
-          align="right"
-          sx={{
-            borderBottom: border,
-            padding: BCDesignTokens.layoutPaddingXsmall,
-            width: '25%', // Ensure width matches header
-          }}
-        >
-          <DocumentStatusChip status={document.status === null ? "nodata" : String(document.status) as DocumentStatus} />
-        </TableCell>
-      </TableRow>
+            {document.document_label ?? "--"}
+          </Typography>
+          <ArrowForwardIos fontSize="small" />
+        </Link>
+      </TableCell>
+      <TableCell
+        align="right"
+        sx={{
+          borderBottom: border,
+          padding: BCDesignTokens.layoutPaddingXsmall,
+          width: '25%',
+        }}
+      >
+        {document.year_issued ?? "--"}
+      </TableCell>
+      <TableCell
+        align="right"
+        sx={{
+          borderBottom: border,
+          padding: BCDesignTokens.layoutPaddingXsmall,
+          width: '25%',
+        }}
+      >
+        <DocumentStatusChip status={document.status === null ? "nodata" : String(document.status) as DocumentStatus} />
+      </TableCell>
+    </TableRow>
+  );
+}
+
+export default function DocumentTableRow({ projectId, document, amendments }: DocumentRowProps) {
+  return (
+    <>
+      <DocumentRow projectId={projectId} document={document} />
+      {amendments?.map((amendment) => (
+        <DocumentRow
+          key={amendment.document_id}
+          projectId={projectId}
+          document={amendment}
+          isAmendment
+        />
+      ))}
       <TableRow key={`empty-row-${document.document_id}`}>
         <TableCell colSpan={12} sx={{ border: 0, py: BCDesignTokens.layoutPaddingXsmall }} />
       </TableRow>

--- a/condition-web/src/models/Document.ts
+++ b/condition-web/src/models/Document.ts
@@ -43,6 +43,7 @@ export interface AllDocumentModel {
   year_issued: number;
   status: boolean;
   is_latest_amendment_added: boolean;
+  parent_document_id?: string;
 }
 
 export interface ProjectDocumentAllAmendmentsModel {


### PR DESCRIPTION
## Summary

When a project has multiple certificate documents, each with their own amendments, the document list was displaying all entries in a flat list with no visual grouping. This made it unclear which amendment belonged to which certificate document.

## Changes

**Backend**
- `document_service.py` — Added `parent_document_id` to each amendment entry returned by `get_all_documents_by_category`, linking it to its parent certificate document's `document_id`
- `schemas/document.py` — Added `parent_document_id` field to `DocumentSchema` so it is included in the API response

**Frontend**
- `models/Document.ts` — Added `parent_document_id?: string` to `AllDocumentModel`
- `DocumentTable.tsx` — Added a `groupDocuments()` function that separates certificate documents from amendments and maps each amendment to its parent; passes the grouped amendments to each row
- `DocumentTableRow.tsx` — Refactored to render a certificate row followed by its nested amendments; amendments are visually indented with additional left padding

