### PR TITLE
CR-184:Document persistent in Extracted Documents tab after adding it to the repo

### DIFF
--- a/condition-api/src/condition_api/resources/extraction_request.py
+++ b/condition-api/src/condition_api/resources/extraction_request.py
@@ -80,10 +80,13 @@ class ExtractionRequestActionResource(Resource):
     @auth.has_one_of_roles([EpicConditionRole.EXTRACT_CONDITIONS.value])
     @cross_origin(origins=allowedorigins())
     def patch(request_id, action):
-        """Perform action (reject)."""
+        """Perform action (reject, manual)."""
         try:
             if action == 'reject':
                 result = ExtractionRequestService.reject_request(request_id)
+                return ExtractionRequestSchema().dump(result), HTTPStatus.OK
+            if action == 'manual':
+                result = ExtractionRequestService.manual_entry_request(request_id)
                 return ExtractionRequestSchema().dump(result), HTTPStatus.OK
             return {"message": "Invalid PATCH action"}, HTTPStatus.BAD_REQUEST
         except ValueError as e:

--- a/condition-api/src/condition_api/services/extraction_request_service.py
+++ b/condition-api/src/condition_api/services/extraction_request_service.py
@@ -135,6 +135,25 @@ class ExtractionRequestService:
         return requests
 
     @staticmethod
+    def manual_entry_request(request_id: int):
+        """Mark an extraction request as manually entered and purge its raw extracted JSON."""
+        req = db.session.query(ExtractionRequest).filter_by(id=request_id).first()
+        if not req:
+            raise ValueError("ExtractionRequest not found")
+        try:
+            req.status = 'manual'
+            req.extracted_data = None
+            req.error_message = None
+
+            db.session.commit()
+        except SQLAlchemyError as exc:
+            db.session.rollback()
+            logger.error("Failed to mark ExtractionRequest id=%s as manual: %s", request_id, exc)
+            raise ValueError("Failed to update extraction request due to a database error.") from exc
+        db.session.refresh(req)
+        return req
+
+    @staticmethod
     def reject_request(request_id: int):
         """Reject an extraction request and purge its raw extracted JSON."""
         req = db.session.query(ExtractionRequest).filter_by(id=request_id).first()

--- a/condition-web/src/components/Documents/DocumentEntryForm.tsx
+++ b/condition-web/src/components/Documents/DocumentEntryForm.tsx
@@ -22,6 +22,7 @@ import { ProjectModel } from "@/models/Project";
 import { DocumentTypes } from "@/utils/enums";
 import { useCreateDocument, useGetDocumentsByProject } from "@/hooks/api/useDocuments";
 import { useCreateAmendment } from "@/hooks/api/useAmendments";
+import { useManualEntryExtractionRequest } from "@/hooks/api/useExtractionRequests";
 import { CreateAmendmentModel } from "@/models/Amendment";
 import { CreateDocumentModel, DocumentModel } from "@/models/Document";
 import { CustomTooltip } from "@/components/Shared/Common";
@@ -41,6 +42,7 @@ type DocumentEntryFormProps = {
         documentTypeId?: number;
         documentLabel?: string;
         dateIssued?: string;
+        extractionRequestId?: number;
     };
 };
 
@@ -164,6 +166,8 @@ export const DocumentEntryForm = ({
         }
     );
 
+    const { mutateAsync: rejectExtractionRequest } = useManualEntryExtractionRequest();
+
     const { mutateAsync: createAmendment } = useCreateAmendment(
         formState.selectedDocumentId ? formState.selectedDocumentId : "",
         {
@@ -210,6 +214,10 @@ export const DocumentEntryForm = ({
                 : await createDocument(payload as CreateDocumentModel);
 
             queryClient.invalidateQueries({ queryKey: ["projects"] });
+
+            if (transferData?.extractionRequestId) {
+                await rejectExtractionRequest(transferData.extractionRequestId);
+            }
 
             if (response) {
                 const navigateTo = isAmendment

--- a/condition-web/src/components/Documents/DocumentEntryPage.tsx
+++ b/condition-web/src/components/Documents/DocumentEntryPage.tsx
@@ -17,6 +17,7 @@ type DocumentEntryPageProps = {
         documentTypeId?: number;
         documentLabel?: string;
         dateIssued?: string;
+        extractionRequestId?: number;
     };
 };
 
@@ -50,7 +51,13 @@ export const DocumentEntryPage = ({
                     documentType={documentType}
                     projectArray={projects}
                     onCancel={() => navigate({ to: "/projects" })}
-                    transferData={manualEntrySearch?.manualEntry ? manualEntrySearch : undefined}
+                    transferData={manualEntrySearch?.manualEntry ? {
+                        projectId: manualEntrySearch.projectId,
+                        documentTypeId: manualEntrySearch.documentTypeId,
+                        documentLabel: manualEntrySearch.documentLabel,
+                        dateIssued: manualEntrySearch.dateIssued,
+                        extractionRequestId: manualEntrySearch.extractionRequestId,
+                    } : undefined}
                 />
             )}
         </Paper>

--- a/condition-web/src/components/ExtractedDocuments/ExtractedDocumentsPage.tsx
+++ b/condition-web/src/components/ExtractedDocuments/ExtractedDocumentsPage.tsx
@@ -435,6 +435,7 @@ export default function ExtractedDocumentsPage() {
                                     projectId: req.project_id,
                                     documentTypeId: req.document_type_id,
                                     documentLabel: req.document_label,
+                                    extractionRequestId: req.id,
                                   },
                                 })
                             }

--- a/condition-web/src/hooks/api/useExtractionRequests.ts
+++ b/condition-web/src/hooks/api/useExtractionRequests.ts
@@ -93,6 +93,20 @@ export const useImportExtractionRequest = () => {
     });
 };
 
+export const useManualEntryExtractionRequest = () => {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: (id: number) =>
+            submitRequest({
+                url: `/extraction-requests/${id}/manual`,
+                method: "patch",
+            }),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ["extraction-requests"] });
+        },
+    });
+};
+
 export const useRejectExtractionRequest = () => {
     const queryClient = useQueryClient();
     return useMutation({

--- a/condition-web/src/routes/_authenticated/documents/extract/index.tsx
+++ b/condition-web/src/routes/_authenticated/documents/extract/index.tsx
@@ -23,6 +23,11 @@ export const Route = createFileRoute(
                 : undefined,
         documentLabel: typeof search.documentLabel === "string" ? search.documentLabel : undefined,
         dateIssued: typeof search.dateIssued === "string" ? search.dateIssued : undefined,
+        extractionRequestId: typeof search.extractionRequestId === "number"
+            ? search.extractionRequestId
+            : typeof search.extractionRequestId === "string" && search.extractionRequestId
+                ? Number(search.extractionRequestId)
+                : undefined,
     }),
     meta: () => [
         { title: "Home", path: "/projects" },


### PR DESCRIPTION
**Fix: Remove failed extraction from Extraction Complete after manual entry**

**Problem**

When a user clicked "Switch to Manual Entry" for a failed extraction and successfully added the document, the original extraction request was never updated. It remained in `status: failed`, causing it to persist in the "Extraction Complete" section indefinitely — and allowing the same document to be manually entered multiple times.

**Changes**

- **Backend — new `manual` status** (`extraction_request_service.py`, `extraction_request.py`): Added a `manual_entry_request()` service method that sets the extraction request status to `manual` and clears `extracted_data`/`error_message`. Exposed it via `PATCH /extraction-requests/{id}/manual`. Unlike `reject`, this does **not** deactivate the associated document, since the document was successfully created through manual entry.

- **Frontend — pass extraction request ID through navigation** (`ExtractedDocumentsPage.tsx`, `DocumentEntryPage.tsx`, route `index.tsx`): The "Switch to Manual Entry" navigation now includes `extractionRequestId` in the search params, propagated through `DocumentEntryPage` into `DocumentEntryForm` via `transferData`.

- **Frontend — call manual mutation on success** (`DocumentEntryForm.tsx`, `useExtractionRequests.ts`): Added `useManualEntryExtractionRequest` hook (`PATCH /manual`). After a document is successfully created via manual entry, the hook is called to mark the originating extraction request as `manual`, removing it from the "Extraction Complete" section.
EOF