### PR TITLE
check valid type of documents before extration

### DIFF
--- a/condition-cron/README.md
+++ b/condition-cron/README.md
@@ -99,6 +99,7 @@ Copy `sample.env` to `.env` and fill in the values.
 | `S3_SERVICE` | S3 service name, usually `s3` |
 | `EXTRACTOR_API_URL` | Azure-hosted extractor API URL (optional) |
 | `EXTRACTOR_API_KEY` | Extractor API key (optional) |
+| `EXTRACTION_UNSUPPORTED_CONFIDENCE_THRESHOLD` | Confidence required to stop extraction as unsupported (default: `0.75`) |
 
 ---
 

--- a/condition-cron/config.py
+++ b/condition-cron/config.py
@@ -8,6 +8,14 @@ from dotenv import find_dotenv, load_dotenv
 load_dotenv(find_dotenv())
 
 
+def _float_env(name: str, default: str) -> float:
+    """Read a float environment variable with a safe default."""
+    try:
+        return float(os.getenv(name, default))
+    except (TypeError, ValueError):
+        return float(default)
+
+
 def get_named_config(config_name: str = 'development'):
     """Return the configuration object based on the name."""
     if config_name in ['production', 'staging', 'default']:
@@ -48,6 +56,10 @@ class _Config:
     EXTRACTOR_API_URL = os.getenv('EXTRACTOR_API_URL', '')
     EXTRACTOR_API_KEY = os.getenv('EXTRACTOR_API_KEY', '')
     OPENAI_API_KEY = os.getenv('OPENAI_API_KEY', '')
+    EXTRACTION_UNSUPPORTED_CONFIDENCE_THRESHOLD = _float_env(
+        'EXTRACTION_UNSUPPORTED_CONFIDENCE_THRESHOLD',
+        '0.75',
+    )
 
     # Queue timing settings shared with condition-api for UI estimates.
     #

--- a/condition-cron/sample.env
+++ b/condition-cron/sample.env
@@ -27,6 +27,10 @@ EXTRACTOR_API_KEY=
 # EXTRACTOR_API_KEY point at the Azure extractor proxy.
 OPENAI_API_KEY=
 
+# Minimum classifier confidence required to stop extraction as unsupported.
+# The gate fails open below this value, so uncertain documents still extract.
+EXTRACTION_UNSUPPORTED_CONFIDENCE_THRESHOLD=0.75
+
 # ── Extraction Queue Timing ───────────────────────────────────────────────────
 # Keep these values in sync with condition-api.
 # Manual update rule:

--- a/condition-cron/src/condition_cron/extraction/document_classifier.py
+++ b/condition-cron/src/condition_cron/extraction/document_classifier.py
@@ -24,6 +24,12 @@ UNSUPPORTED_DOCUMENT_FAMILIES = {
     "unsupported",
 }
 
+UNSUPPORTED_CATEGORIES = {
+    "amendment_document",
+    "invalid_document",
+    "unreadable_format",
+}
+
 SUPPORTED_SIGNALS = [
     "environmental assessment certificate",
     "environmental assessment office",
@@ -93,11 +99,17 @@ def _clip_document_text(file_text: str) -> str:
     return f"{text[:half]}\n\n[...document text clipped...]\n\n{text[-half:]}"
 
 
-def _unsupported_eligibility(reason: str, evidence: list[str], confidence: float = 1.0) -> Dict[str, Any]:
+def _unsupported_eligibility(
+    reason: str,
+    evidence: list[str],
+    confidence: float = 1.0,
+    unsupported_category: str = "invalid_document",
+) -> Dict[str, Any]:
     """Build a consistent unsupported eligibility response."""
     return {
         "is_supported_document": False,
         "document_family": "unsupported",
+        "unsupported_category": unsupported_category,
         "confidence": confidence,
         "reason": reason,
         "evidence": evidence,
@@ -109,10 +121,20 @@ def _fail_open_eligibility(reason: str) -> Dict[str, Any]:
     return {
         "is_supported_document": True,
         "document_family": "uncertain",
+        "unsupported_category": None,
         "confidence": 0.0,
         "reason": reason,
         "evidence": [],
     }
+
+
+def _unsupported_category_for(document_family: str, category: str = None) -> str:
+    """Return one of the supported UI-facing unsupported categories."""
+    if document_family == "amendment":
+        return "amendment_document"
+    if category in UNSUPPORTED_CATEGORIES:
+        return category
+    return "invalid_document"
 
 
 def _normalize_eligibility_result(result: Dict[str, Any]) -> Dict[str, Any]:
@@ -130,6 +152,13 @@ def _normalize_eligibility_result(result: Dict[str, Any]) -> Dict[str, Any]:
         )
     if document_family in UNSUPPORTED_DOCUMENT_FAMILIES:
         is_supported = False
+
+    unsupported_category = None
+    if not is_supported:
+        unsupported_category = _unsupported_category_for(
+            document_family,
+            result.get("unsupported_category"),
+        )
 
     try:
         confidence = float(result.get("confidence", 0.0))
@@ -153,6 +182,7 @@ def _normalize_eligibility_result(result: Dict[str, Any]) -> Dict[str, Any]:
     return {
         "is_supported_document": is_supported,
         "document_family": document_family,
+        "unsupported_category": unsupported_category,
         "confidence": confidence,
         "reason": reason,
         "evidence": evidence,
@@ -196,6 +226,7 @@ def classify_document_eligibility(file_text: str) -> Dict[str, Any]:
             "No readable text was found in the document.",
             ["No readable text"],
             confidence=1.0,
+            unsupported_category="unreadable_format",
         )
 
     supported_signals = _find_signals(readable_text, SUPPORTED_SIGNALS)
@@ -222,6 +253,16 @@ def classify_document_eligibility(file_text: str) -> Dict[str, Any]:
                             "type": "string",
                             "enum": sorted(DOCUMENT_FAMILIES),
                             "description": "The closest supported document family, or unsupported/uncertain.",
+                        },
+                        "unsupported_category": {
+                            "type": "string",
+                            "enum": sorted(UNSUPPORTED_CATEGORIES),
+                            "description": (
+                                "Only set when is_supported_document is false. Use "
+                                "amendment_document for amendment documents, unreadable_format "
+                                "when no readable text is present, and invalid_document for other "
+                                "unrelated documents."
+                            ),
                         },
                         "confidence": {
                             "type": "number",
@@ -260,6 +301,8 @@ def classify_document_eligibility(file_text: str) -> Dict[str, Any]:
         "amendment documents. Amendments are not supported by the conditions repository "
         "yet; if the document is an amendment, mark it unsupported with document_family "
         "'amendment'.\n\n"
+        "When a document is unsupported, also set unsupported_category to exactly one "
+        "of these values: amendment_document, invalid_document, unreadable_format.\n\n"
         "Be permissive: if the document could reasonably be an EAO/environmental "
         "assessment conditions document, mark it supported. Mark unsupported only "
         "when the document is clearly unrelated. Numbered sections alone are not "

--- a/condition-cron/src/condition_cron/extraction/document_classifier.py
+++ b/condition-cron/src/condition_cron/extraction/document_classifier.py
@@ -7,6 +7,296 @@ from condition_cron.extraction.client import get_openai_client
 
 logger = logging.getLogger(__name__)
 
+ELIGIBILITY_TEXT_LIMIT = 16000
+
+DOCUMENT_FAMILIES = {
+    "eao_certificate",
+    "schedule_b_table_of_conditions",
+    "order_conditions",
+    "amendment",
+    "other_environmental_assessment_conditions",
+    "unsupported",
+    "uncertain",
+}
+
+UNSUPPORTED_DOCUMENT_FAMILIES = {
+    "amendment",
+    "unsupported",
+}
+
+SUPPORTED_SIGNALS = [
+    "environmental assessment certificate",
+    "environmental assessment office",
+    "schedule b",
+    "table of conditions",
+    "certificate holder",
+    "the holder must",
+    "holder must",
+    "bceaa",
+    "environmental assessment act",
+    "eao",
+    "condition 1",
+    "condition 2",
+    "certified project description",
+    "mitigation measures",
+    "management plan",
+    "prior to construction",
+    "prior to operations",
+]
+
+UNSUPPORTED_SIGNALS = [
+    "amendment to environmental assessment certificate",
+    "certificate amendment",
+    "amendment certificate",
+    "amended certificate",
+    "amendment order",
+    "amendment",
+    "rental application",
+    "tenant",
+    "landlord",
+    "monthly rent",
+    "lease agreement",
+    "employment application",
+    "resume",
+    "invoice",
+    "purchase order",
+    "vehicle registration",
+    "emergency contact",
+    "applicant income",
+    "credit check",
+]
+
+
+def _readable_text(file_text: str) -> str:
+    """Collapse whitespace for lightweight text checks."""
+    return " ".join((file_text or "").split())
+
+
+def _normalized_text(file_text: str) -> str:
+    """Normalize text for case-insensitive signal matching."""
+    return _readable_text(file_text).lower()
+
+
+def _find_signals(file_text: str, signals: list[str], limit: int = 8) -> list[str]:
+    """Return matched signal phrases in their configured order."""
+    text = _normalized_text(file_text)
+    return [signal for signal in signals if signal in text][:limit]
+
+
+def _clip_document_text(file_text: str) -> str:
+    """Keep enough text for classification without sending the whole document."""
+    text = _readable_text(file_text)
+    if len(text) <= ELIGIBILITY_TEXT_LIMIT:
+        return text
+
+    half = ELIGIBILITY_TEXT_LIMIT // 2
+    return f"{text[:half]}\n\n[...document text clipped...]\n\n{text[-half:]}"
+
+
+def _unsupported_eligibility(reason: str, evidence: list[str], confidence: float = 1.0) -> Dict[str, Any]:
+    """Build a consistent unsupported eligibility response."""
+    return {
+        "is_supported_document": False,
+        "document_family": "unsupported",
+        "confidence": confidence,
+        "reason": reason,
+        "evidence": evidence,
+    }
+
+
+def _fail_open_eligibility(reason: str) -> Dict[str, Any]:
+    """Allow extraction when eligibility classification cannot make a safe call."""
+    return {
+        "is_supported_document": True,
+        "document_family": "uncertain",
+        "confidence": 0.0,
+        "reason": reason,
+        "evidence": [],
+    }
+
+
+def _normalize_eligibility_result(result: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize model output so downstream blocking logic stays simple."""
+    is_supported = result.get("is_supported_document")
+    if not isinstance(is_supported, bool):
+        is_supported = True
+
+    document_family = result.get("document_family")
+    if document_family not in DOCUMENT_FAMILIES:
+        document_family = (
+            "other_environmental_assessment_conditions"
+            if is_supported
+            else "unsupported"
+        )
+    if document_family in UNSUPPORTED_DOCUMENT_FAMILIES:
+        is_supported = False
+
+    try:
+        confidence = float(result.get("confidence", 0.0))
+    except (TypeError, ValueError):
+        confidence = 0.0
+    confidence = max(0.0, min(confidence, 1.0))
+
+    evidence = result.get("evidence") or []
+    if not isinstance(evidence, list):
+        evidence = [str(evidence)]
+    evidence = [str(item).strip() for item in evidence if str(item).strip()]
+
+    reason = str(result.get("reason") or "").strip()
+    if not reason:
+        reason = (
+            "Document appears eligible for condition extraction."
+            if is_supported
+            else "Document does not appear to be a supported EAO conditions document."
+        )
+
+    return {
+        "is_supported_document": is_supported,
+        "document_family": document_family,
+        "confidence": confidence,
+        "reason": reason,
+        "evidence": evidence,
+    }
+
+
+def is_document_supported_for_extraction(
+    eligibility: Dict[str, Any],
+    unsupported_confidence_threshold: float = 0.75,
+) -> bool:
+    """Return False only for high-confidence unsupported classifications.
+
+    The gate intentionally fails open. If the classifier is uncertain, extraction
+    continues so staff review can catch any bad output instead of hiding a valid
+    document.
+    """
+    if eligibility.get("document_family") not in UNSUPPORTED_DOCUMENT_FAMILIES and eligibility.get(
+        "is_supported_document",
+        True,
+    ):
+        return True
+
+    try:
+        confidence = float(eligibility.get("confidence", 0.0))
+    except (TypeError, ValueError):
+        confidence = 0.0
+
+    return confidence < unsupported_confidence_threshold
+
+
+def classify_document_eligibility(file_text: str) -> Dict[str, Any]:
+    """Classify whether a document should be sent to condition extraction.
+
+    This is a content gate, not a structure classifier. It should reject only
+    documents that are clearly unrelated to EAO/environmental assessment
+    conditions.
+    """
+    readable_text = _readable_text(file_text)
+    if not readable_text:
+        return _unsupported_eligibility(
+            "No readable text was found in the document.",
+            ["No readable text"],
+            confidence=1.0,
+        )
+
+    supported_signals = _find_signals(readable_text, SUPPORTED_SIGNALS)
+    unsupported_signals = _find_signals(readable_text, UNSUPPORTED_SIGNALS)
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "classify_document_eligibility",
+                "description": "Decide whether a document is eligible for EAO condition extraction.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "is_supported_document": {
+                            "type": "boolean",
+                            "description": (
+                                "True when the document appears to be an EAO/environmental assessment "
+                                "certificate, order, Schedule B, table of conditions, or similar "
+                                "condition/commitment document. False for amendment documents."
+                            ),
+                        },
+                        "document_family": {
+                            "type": "string",
+                            "enum": sorted(DOCUMENT_FAMILIES),
+                            "description": "The closest supported document family, or unsupported/uncertain.",
+                        },
+                        "confidence": {
+                            "type": "number",
+                            "description": "Confidence in this eligibility decision, from 0.0 to 1.0.",
+                        },
+                        "reason": {
+                            "type": "string",
+                            "description": "Short staff-facing explanation for the decision.",
+                        },
+                        "evidence": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Short phrases from the document that support the decision.",
+                        },
+                    },
+                    "required": [
+                        "is_supported_document",
+                        "document_family",
+                        "confidence",
+                        "reason",
+                        "evidence",
+                    ],
+                },
+            },
+        }
+    ]
+
+    prompt = (
+        "Classify whether this file should be processed by an EAO conditions extractor.\n\n"
+        "Supported documents include BC Environmental Assessment Office certificates, "
+        "Schedule B/Table of Conditions documents, orders with conditions, and similar "
+        "environmental assessment condition or commitment documents.\n\n"
+        "Unsupported documents include rental applications, leases, invoices, resumes, "
+        "employment forms, generic applications, contracts unrelated to environmental "
+        "assessment conditions, files with no condition-like EAO content, and EAO "
+        "amendment documents. Amendments are not supported by the conditions repository "
+        "yet; if the document is an amendment, mark it unsupported with document_family "
+        "'amendment'.\n\n"
+        "Be permissive: if the document could reasonably be an EAO/environmental "
+        "assessment conditions document, mark it supported. Mark unsupported only "
+        "when the document is clearly unrelated. Numbered sections alone are not "
+        "enough; look for domain evidence and obligation language.\n\n"
+        f"Readable text character count: {len(readable_text)}\n"
+        f"Matched supported keyword hints: {supported_signals or 'none'}\n"
+        f"Matched unsupported keyword hints: {unsupported_signals or 'none'}\n\n"
+        f"Document text:\n\n{_clip_document_text(readable_text)}"
+    )
+
+    messages = [{"role": "user", "content": prompt}]
+
+    try:
+        client = get_openai_client()
+        completion = client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=messages,
+            tools=tools,
+            temperature=0.0,
+            tool_choice={"type": "function", "function": {"name": "classify_document_eligibility"}},
+        )
+
+        arguments = completion.choices[0].message.tool_calls[0].function.arguments
+        result = _normalize_eligibility_result(json.loads(arguments))
+        logger.info(
+            "Document Eligibility - Supported: %s, Family: %s, Confidence: %.2f, Reason: %s",
+            result["is_supported_document"],
+            result["document_family"],
+            result["confidence"],
+            result["reason"],
+        )
+        return result
+
+    except Exception as e:
+        logger.error("Eligibility classification error: %s", e, exc_info=True)
+        return _fail_open_eligibility("Eligibility classifier failed; continuing extraction.")
+
 
 def classify_document(file_text: str) -> Dict[str, Any]:
     """Classify the structure of a document to determine the extraction strategy.

--- a/condition-cron/src/condition_cron/extraction/extractor.py
+++ b/condition-cron/src/condition_cron/extraction/extractor.py
@@ -15,6 +15,12 @@ logger = logging.getLogger(__name__)
 
 MODEL = "gpt-4o-2024-05-13"
 SCHEMAS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "schemas")
+EXTRACTION_SCOPE_INSTRUCTION = (
+    "Extract only legally binding environmental assessment certificate, order, "
+    "Schedule B, table-of-conditions, or similar EAO condition/commitment text. "
+    "If the text is not from a supported environmental assessment conditions "
+    "document, return an empty conditions array."
+)
 
 
 # ---------------------------------------------------------------------------
@@ -42,6 +48,11 @@ def _read_file_text(file_path: str) -> str:
             raise ValueError("Unsupported file type. Only PDF and TXT files are supported.")
 
 
+def read_file_text(file_path: str) -> str:
+    """Read text from a supported document file path."""
+    return _read_file_text(file_path)
+
+
 # ---------------------------------------------------------------------------
 # Custom exceptions
 # ---------------------------------------------------------------------------
@@ -57,13 +68,14 @@ class LengthFinishReasonError(FinishReasonError):
 # Document classification + count (new entry point, replaces count_conditions)
 # ---------------------------------------------------------------------------
 
-def classify_and_count(file_path: str) -> Dict[str, Any]:
+def classify_and_count(file_path: str, file_text: str = None) -> Dict[str, Any]:
     """Classify document structure and estimate condition count.
 
     Returns a dict with: document_type, has_numbered_conditions,
     section_headers, estimated_item_count.
     """
-    file_text = _read_file_text(file_path)
+    if file_text is None:
+        file_text = _read_file_text(file_path)
     classification = classify_document(file_text)
     return classification
 
@@ -133,6 +145,7 @@ def _extract_numbered_range(file_path: str, starting_condition_number: int, endi
 
     tools = [tool_schema]
     messages = [{"role": "user", "content": (
+        f"{EXTRACTION_SCOPE_INSTRUCTION}\n\n"
         f"Here is a document with conditions:\n\n{file_text}\n\n"
         f"Extract conditions {starting_condition_number} to {ending_condition_number}."
     )}]
@@ -202,6 +215,7 @@ def _extract_by_pages(file_path: str, classification: Dict[str, Any], pages_per_
         # Build prompt based on document type
         if doc_type == "table_format":
             prompt = (
+                f"{EXTRACTION_SCOPE_INSTRUCTION}\n\n"
                 f"Here is a section of an environmental assessment document (pages {start_page}-{end_page}). "
                 f"The document contains conditions/commitments organized in a table format.\n\n"
                 f"{page_text}\n\n"
@@ -215,6 +229,7 @@ def _extract_by_pages(file_path: str, classification: Dict[str, Any], pages_per_
             if section_headers:
                 section_info = f"Known section headers in this document: {', '.join(section_headers)}. "
             prompt = (
+                f"{EXTRACTION_SCOPE_INSTRUCTION}\n\n"
                 f"Here is a section of an environmental assessment document (pages {start_page}-{end_page}). "
                 f"The document contains commitments organized as bullet points under topic headings. "
                 f"{section_info}\n\n"
@@ -230,6 +245,7 @@ def _extract_by_pages(file_path: str, classification: Dict[str, Any], pages_per_
             )
         else:  # mixed or fallback
             prompt = (
+                f"{EXTRACTION_SCOPE_INSTRUCTION}\n\n"
                 f"Here is a section of an environmental assessment document (pages {start_page}-{end_page}).\n\n"
                 f"{page_text}\n\n"
                 f"Extract every discrete condition, commitment, or requirement from this section. "

--- a/condition-cron/src/condition_cron/services/db_service.py
+++ b/condition-cron/src/condition_cron/services/db_service.py
@@ -168,6 +168,20 @@ def mark_failed(request_id: int, error_message: str) -> None:
     _update_extraction_request_state(request_id, 'failed', error_message=error_message)
 
 
+def mark_unsupported(request_id: int, reason: str, eligibility: dict) -> None:
+    """Mark an extraction request as unsupported with classifier details."""
+    extracted_data = {
+        "conditions": [],
+        "eligibility": eligibility or {},
+    }
+    _update_extraction_request_state(
+        request_id,
+        'unsupported',
+        error_message=reason,
+        extracted_data=extracted_data,
+    )
+
+
 def save_extraction_result(request_id: int, extracted_data: dict) -> None:
     """Save parsed extraction JSON and mark the request completed."""
     _update_extraction_request_state(request_id, 'completed', extracted_data=extracted_data)

--- a/condition-cron/src/condition_cron/services/extraction_service.py
+++ b/condition-cron/src/condition_cron/services/extraction_service.py
@@ -7,7 +7,41 @@ service can run without the old Gradio/manual condition-parser module.
 import logging
 import os
 
+from flask import current_app
+
 logger = logging.getLogger(__name__)
+
+
+class UnsupportedDocumentError(Exception):
+    """Raised when a document is confidently unrelated to EAO conditions."""
+
+    def __init__(self, eligibility: dict):
+        self.eligibility = eligibility
+        reason = eligibility.get(
+            "reason",
+            "This document does not appear to be a supported EAO conditions document.",
+        )
+        super().__init__(reason)
+
+
+def _get_unsupported_confidence_threshold() -> float:
+    """Return the configured threshold for blocking unsupported documents."""
+    try:
+        configured_value = current_app.config.get(
+            "EXTRACTION_UNSUPPORTED_CONFIDENCE_THRESHOLD",
+            os.getenv("EXTRACTION_UNSUPPORTED_CONFIDENCE_THRESHOLD", "0.75"),
+        )
+    except RuntimeError:
+        configured_value = os.getenv("EXTRACTION_UNSUPPORTED_CONFIDENCE_THRESHOLD", "0.75")
+
+    try:
+        return float(configured_value)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid EXTRACTION_UNSUPPORTED_CONFIDENCE_THRESHOLD=%r; using 0.75",
+            configured_value,
+        )
+        return 0.75
 
 
 def extract_and_enrich(file_path: str) -> dict:
@@ -17,11 +51,31 @@ def extract_and_enrich(file_path: str) -> dict:
     Returns a dict with 'conditions' and 'classification' keys.
     """
     # Imported here so Flask has loaded env vars before the OpenAI client is built.
-    from condition_cron.extraction.extractor import classify_and_count, extract_and_enrich_all
+    from condition_cron.extraction.document_classifier import (
+        classify_document_eligibility,
+        is_document_supported_for_extraction,
+    )
+    from condition_cron.extraction.extractor import (
+        classify_and_count,
+        extract_and_enrich_all,
+        read_file_text,
+    )
     from condition_cron.extraction.first_nations import process_single_pdf
 
+    file_text = read_file_text(file_path)
+    eligibility = classify_document_eligibility(file_text)
+    threshold = _get_unsupported_confidence_threshold()
+
+    if not is_document_supported_for_extraction(eligibility, threshold):
+        logger.info(
+            "Skipping unsupported document %s: %s",
+            file_path,
+            eligibility.get("reason"),
+        )
+        raise UnsupportedDocumentError(eligibility)
+
     logger.info('Classifying %s', file_path)
-    classification = classify_and_count(file_path)
+    classification = classify_and_count(file_path, file_text=file_text)
 
     logger.info('Extracting and enriching conditions from %s', file_path)
     result = extract_and_enrich_all(file_path, classification)
@@ -29,6 +83,7 @@ def extract_and_enrich(file_path: str) -> dict:
     if result and 'conditions' in result and file_path.endswith('.pdf'):
         result = process_single_pdf(file_path, result)
 
+    result['eligibility'] = eligibility
     result['classification'] = classification
     logger.info('Extraction complete: %d condition(s)', len(result.get('conditions', [])))
     return result

--- a/condition-cron/src/condition_cron/tasks/process_documents.py
+++ b/condition-cron/src/condition_cron/tasks/process_documents.py
@@ -20,7 +20,7 @@ class ProcessDocuments:
             logger.info('No pending extraction requests found.')
             return
 
-        success, failed = 0, 0
+        success, failed, unsupported = 0, 0, 0
 
         for req in pending:
             request_id = req['id']
@@ -64,6 +64,23 @@ class ProcessDocuments:
                 success += 1
                 logger.info('Successfully processed extraction request %d', request_id)
 
+            except extraction_service.UnsupportedDocumentError as exc:
+                unsupported += 1
+                error_msg = str(exc)
+                logger.info(
+                    'Unsupported extraction request %d: %s',
+                    request_id,
+                    error_msg,
+                )
+                try:
+                    if db_service.get_request_status(request_id) == 'rejected':
+                        logger.info('Skipping unsupported update for rejected extraction request %d', request_id)
+                        continue
+
+                    db_service.mark_unsupported(request_id, error_msg, exc.eligibility)
+                except Exception:
+                    logger.error('Could not update status to unsupported for request %d', request_id)
+
             except Exception as exc:
                 failed += 1
                 error_msg = str(exc)
@@ -77,4 +94,9 @@ class ProcessDocuments:
                 if local_path and os.path.exists(local_path):
                     os.remove(local_path)
 
-        logger.info('ProcessDocuments complete — success: %d, failed: %d', success, failed)
+        logger.info(
+            'ProcessDocuments complete — success: %d, unsupported: %d, failed: %d',
+            success,
+            unsupported,
+            failed,
+        )

--- a/condition-cron/tests/test_document_classifier.py
+++ b/condition-cron/tests/test_document_classifier.py
@@ -1,0 +1,102 @@
+"""Tests for document eligibility classification helpers."""
+
+import json
+from types import SimpleNamespace
+
+from condition_cron.extraction.document_classifier import (
+    classify_document_eligibility,
+    is_document_supported_for_extraction,
+)
+
+
+def test_classify_document_eligibility_rejects_empty_text():
+    """Blank/scanned text should stop before extraction."""
+    result = classify_document_eligibility("")
+
+    assert result["is_supported_document"] is False
+    assert result["document_family"] == "unsupported"
+    assert result["confidence"] == 1.0
+
+
+def test_is_document_supported_for_extraction_blocks_high_confidence_unsupported():
+    """A confident unsupported result should block extraction."""
+    eligibility = {
+        "is_supported_document": False,
+        "document_family": "unsupported",
+        "confidence": 0.9,
+        "reason": "Rental application.",
+        "evidence": ["rental application", "tenant"],
+    }
+
+    assert is_document_supported_for_extraction(eligibility, 0.75) is False
+
+
+def test_is_document_supported_for_extraction_allows_uncertain_unsupported():
+    """Low-confidence unsupported results should continue extraction."""
+    eligibility = {
+        "is_supported_document": False,
+        "document_family": "unsupported",
+        "confidence": 0.5,
+        "reason": "Not enough evidence.",
+        "evidence": [],
+    }
+
+    assert is_document_supported_for_extraction(eligibility, 0.75) is True
+
+
+def test_is_document_supported_for_extraction_blocks_amendment_family():
+    """Amendments are known unsupported even though they are EAO documents."""
+    eligibility = {
+        "is_supported_document": True,
+        "document_family": "amendment",
+        "confidence": 0.9,
+        "reason": "This is an amendment document.",
+        "evidence": ["Amendment to Environmental Assessment Certificate"],
+    }
+
+    assert is_document_supported_for_extraction(eligibility, 0.75) is False
+
+
+def test_classify_document_eligibility_normalizes_amendment_as_unsupported(monkeypatch):
+    """The model cannot accidentally pass amendments by setting supported=true."""
+    arguments = {
+        "is_supported_document": True,
+        "document_family": "amendment",
+        "confidence": 0.9,
+        "reason": "This is an amendment to an environmental assessment certificate.",
+        "evidence": ["Amendment to Environmental Assessment Certificate"],
+    }
+
+    class _FakeCompletions:
+        def create(self, **kwargs):  # noqa: ARG002
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(
+                            tool_calls=[
+                                SimpleNamespace(
+                                    function=SimpleNamespace(
+                                        arguments=json.dumps(arguments)
+                                    )
+                                )
+                            ]
+                        )
+                    )
+                ]
+            )
+
+    fake_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=_FakeCompletions())
+    )
+    monkeypatch.setattr(
+        "condition_cron.extraction.document_classifier.get_openai_client",
+        lambda: fake_client,
+    )
+
+    result = classify_document_eligibility(
+        "Amendment to Environmental Assessment Certificate #M24-01"
+    )
+
+    assert result["is_supported_document"] is False
+    assert result["document_family"] == "amendment"
+    assert result["confidence"] == 0.9

--- a/condition-cron/tests/test_document_classifier.py
+++ b/condition-cron/tests/test_document_classifier.py
@@ -15,6 +15,7 @@ def test_classify_document_eligibility_rejects_empty_text():
 
     assert result["is_supported_document"] is False
     assert result["document_family"] == "unsupported"
+    assert result["unsupported_category"] == "unreadable_format"
     assert result["confidence"] == 1.0
 
 
@@ -23,6 +24,7 @@ def test_is_document_supported_for_extraction_blocks_high_confidence_unsupported
     eligibility = {
         "is_supported_document": False,
         "document_family": "unsupported",
+        "unsupported_category": "invalid_document",
         "confidence": 0.9,
         "reason": "Rental application.",
         "evidence": ["rental application", "tenant"],
@@ -36,6 +38,7 @@ def test_is_document_supported_for_extraction_allows_uncertain_unsupported():
     eligibility = {
         "is_supported_document": False,
         "document_family": "unsupported",
+        "unsupported_category": "invalid_document",
         "confidence": 0.5,
         "reason": "Not enough evidence.",
         "evidence": [],
@@ -49,6 +52,7 @@ def test_is_document_supported_for_extraction_blocks_amendment_family():
     eligibility = {
         "is_supported_document": True,
         "document_family": "amendment",
+        "unsupported_category": "amendment_document",
         "confidence": 0.9,
         "reason": "This is an amendment document.",
         "evidence": ["Amendment to Environmental Assessment Certificate"],
@@ -62,6 +66,7 @@ def test_classify_document_eligibility_normalizes_amendment_as_unsupported(monke
     arguments = {
         "is_supported_document": True,
         "document_family": "amendment",
+        "unsupported_category": "invalid_document",
         "confidence": 0.9,
         "reason": "This is an amendment to an environmental assessment certificate.",
         "evidence": ["Amendment to Environmental Assessment Certificate"],
@@ -99,4 +104,47 @@ def test_classify_document_eligibility_normalizes_amendment_as_unsupported(monke
 
     assert result["is_supported_document"] is False
     assert result["document_family"] == "amendment"
+    assert result["unsupported_category"] == "amendment_document"
     assert result["confidence"] == 0.9
+
+
+def test_classify_document_eligibility_assigns_default_invalid_category(monkeypatch):
+    """Unsupported non-amendment documents default to the invalid document category."""
+    arguments = {
+        "is_supported_document": False,
+        "document_family": "unsupported",
+        "confidence": 0.95,
+        "reason": "This appears to be a rental application.",
+        "evidence": ["rental application", "tenant"],
+    }
+
+    class _FakeCompletions:
+        def create(self, **kwargs):  # noqa: ARG002
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(
+                            tool_calls=[
+                                SimpleNamespace(
+                                    function=SimpleNamespace(
+                                        arguments=json.dumps(arguments)
+                                    )
+                                )
+                            ]
+                        )
+                    )
+                ]
+            )
+
+    fake_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=_FakeCompletions())
+    )
+    monkeypatch.setattr(
+        "condition_cron.extraction.document_classifier.get_openai_client",
+        lambda: fake_client,
+    )
+
+    result = classify_document_eligibility("Rental application tenant landlord")
+
+    assert result["is_supported_document"] is False
+    assert result["unsupported_category"] == "invalid_document"

--- a/condition-cron/tests/test_extraction_service.py
+++ b/condition-cron/tests/test_extraction_service.py
@@ -1,0 +1,76 @@
+"""Tests for extraction service eligibility gating."""
+
+import pytest
+
+from condition_cron.services import extraction_service
+
+
+def _unsupported_eligibility(confidence: float) -> dict:
+    return {
+        "is_supported_document": False,
+        "document_family": "unsupported",
+        "confidence": confidence,
+        "reason": "This appears to be a rental application.",
+        "evidence": ["rental application", "tenant", "landlord"],
+    }
+
+
+def test_extract_and_enrich_blocks_high_confidence_unsupported(monkeypatch, tmp_path):
+    """Confident unrelated documents should not reach extraction."""
+    document = tmp_path / "rental.txt"
+    document.write_text("Rental application tenant landlord monthly rent.", encoding="utf-8")
+
+    monkeypatch.setattr(
+        "condition_cron.extraction.document_classifier.classify_document_eligibility",
+        lambda file_text: _unsupported_eligibility(0.9),
+    )
+    monkeypatch.setattr(
+        "condition_cron.services.extraction_service._get_unsupported_confidence_threshold",
+        lambda: 0.75,
+    )
+
+    def fail_if_called(*args, **kwargs):  # noqa: ARG001
+        raise AssertionError("Extraction should not run for unsupported documents")
+
+    monkeypatch.setattr("condition_cron.extraction.extractor.classify_and_count", fail_if_called)
+    monkeypatch.setattr("condition_cron.extraction.extractor.extract_and_enrich_all", fail_if_called)
+
+    with pytest.raises(extraction_service.UnsupportedDocumentError) as exc:
+        extraction_service.extract_and_enrich(str(document))
+
+    assert exc.value.eligibility["confidence"] == 0.9
+
+
+def test_extract_and_enrich_allows_low_confidence_unsupported(monkeypatch, tmp_path):
+    """Uncertain documents should continue through the existing extraction path."""
+    document = tmp_path / "maybe-conditions.txt"
+    document.write_text("Some numbered commitments with limited context.", encoding="utf-8")
+
+    classification = {
+        "document_type": "numbered_conditions",
+        "has_numbered_conditions": True,
+        "section_headers": [],
+        "estimated_item_count": 0,
+    }
+
+    monkeypatch.setattr(
+        "condition_cron.extraction.document_classifier.classify_document_eligibility",
+        lambda file_text: _unsupported_eligibility(0.5),
+    )
+    monkeypatch.setattr(
+        "condition_cron.services.extraction_service._get_unsupported_confidence_threshold",
+        lambda: 0.75,
+    )
+    monkeypatch.setattr(
+        "condition_cron.extraction.extractor.classify_and_count",
+        lambda path, file_text=None: classification,
+    )
+    monkeypatch.setattr(
+        "condition_cron.extraction.extractor.extract_and_enrich_all",
+        lambda path, extracted_classification: {"conditions": []},
+    )
+
+    result = extraction_service.extract_and_enrich(str(document))
+
+    assert result["classification"] == classification
+    assert result["eligibility"]["confidence"] == 0.5

--- a/condition-cron/tests/test_extraction_service.py
+++ b/condition-cron/tests/test_extraction_service.py
@@ -9,6 +9,7 @@ def _unsupported_eligibility(confidence: float) -> dict:
     return {
         "is_supported_document": False,
         "document_family": "unsupported",
+        "unsupported_category": "invalid_document",
         "confidence": confidence,
         "reason": "This appears to be a rental application.",
         "evidence": ["rental application", "tenant", "landlord"],

--- a/condition-cron/tests/test_process_documents.py
+++ b/condition-cron/tests/test_process_documents.py
@@ -63,6 +63,7 @@ def test_process_marks_unsupported_documents(monkeypatch, tmp_path):
     eligibility = {
         "is_supported_document": False,
         "document_family": "unsupported",
+        "unsupported_category": "invalid_document",
         "confidence": 0.9,
         "reason": "This appears to be a rental application.",
         "evidence": ["rental application", "tenant"],

--- a/condition-cron/tests/test_process_documents.py
+++ b/condition-cron/tests/test_process_documents.py
@@ -1,6 +1,7 @@
 """Tests for document processing orchestration."""
 
 from condition_cron.tasks.process_documents import ProcessDocuments
+from condition_cron.services import extraction_service
 
 
 def test_process_skips_save_when_request_was_rejected(monkeypatch, tmp_path):
@@ -53,3 +54,77 @@ def test_process_skips_save_when_request_was_rejected(monkeypatch, tmp_path):
     ProcessDocuments.process()
 
     assert calls == {"saved": False, "failed": False}
+
+
+def test_process_marks_unsupported_documents(monkeypatch, tmp_path):
+    """Unsupported documents should get a clear status instead of a generic failure."""
+    downloaded = tmp_path / "rental.pdf"
+    downloaded.write_text("pdf")
+    eligibility = {
+        "is_supported_document": False,
+        "document_family": "unsupported",
+        "confidence": 0.9,
+        "reason": "This appears to be a rental application.",
+        "evidence": ["rental application", "tenant"],
+    }
+    calls = {"saved": False, "failed": False, "unsupported": False}
+
+    monkeypatch.setattr(
+        "condition_cron.tasks.process_documents.db_service.get_pending_requests",
+        lambda: [{
+            "id": 2,
+            "s3_url": "condition_extraction_documents/rental.pdf",
+            "project_id": "project-1",
+            "document_id": "document-1",
+            "project_name": "Project 1",
+            "project_type": "Mines",
+            "document_label": "Rental Application",
+            "document_file_name": "rental.pdf",
+            "document_type": "Certificate",
+            "date_issued": None,
+            "act": None,
+        }],
+    )
+    monkeypatch.setattr(
+        "condition_cron.tasks.process_documents.db_service.mark_processing",
+        lambda request_id: None,
+    )
+    monkeypatch.setattr(
+        "condition_cron.tasks.process_documents.s3_service.download_file",
+        lambda s3_key: str(downloaded),
+    )
+
+    def raise_unsupported(path):  # noqa: ARG001
+        raise extraction_service.UnsupportedDocumentError(eligibility)
+
+    monkeypatch.setattr(
+        "condition_cron.tasks.process_documents.extraction_service.extract_and_enrich",
+        raise_unsupported,
+    )
+    monkeypatch.setattr(
+        "condition_cron.tasks.process_documents.db_service.get_request_status",
+        lambda request_id: "processing",
+    )
+    monkeypatch.setattr(
+        "condition_cron.tasks.process_documents.db_service.mark_unsupported",
+        lambda request_id, reason, extracted_eligibility: calls.update(
+            unsupported=True,
+            reason=reason,
+            eligibility=extracted_eligibility,
+        ),
+    )
+    monkeypatch.setattr(
+        "condition_cron.tasks.process_documents.db_service.save_extraction_result",
+        lambda request_id, extracted_data: calls.update(saved=True),
+    )
+    monkeypatch.setattr(
+        "condition_cron.tasks.process_documents.db_service.mark_failed",
+        lambda request_id, error_message: calls.update(failed=True),
+    )
+
+    ProcessDocuments.process()
+
+    assert calls["unsupported"] is True
+    assert calls["eligibility"] == eligibility
+    assert calls["saved"] is False
+    assert calls["failed"] is False

--- a/condition-web/src/components/ExtractedDocuments/ExtractedDocumentsPage.tsx
+++ b/condition-web/src/components/ExtractedDocuments/ExtractedDocumentsPage.tsx
@@ -250,7 +250,11 @@ export default function ExtractedDocumentsPage() {
   };
 
   const completedRequests =
-    requests?.filter((r) => r.status === "completed" || r.status === "failed") ?? [];
+    requests?.filter((r) => (
+      r.status === "completed" ||
+      r.status === "failed" ||
+      r.status === "unsupported"
+    )) ?? [];
   const pendingRequests =
     requests
       ?.filter((r) => r.status === "pending" || r.status === "processing")
@@ -397,7 +401,19 @@ export default function ExtractedDocumentsPage() {
                 ) : (
                   completedRequests.map((req) => {
                     const isSuccess = req.status === "completed";
+                    const isUnsupported = req.status === "unsupported";
                     const conditionCount = req.extracted_data?.conditions?.length ?? 0;
+                    const statusTitle = isSuccess
+                      ? "Extraction Complete!"
+                      : isUnsupported
+                        ? "Unsupported Document"
+                        : "Extraction Failed";
+                    const statusMessage = isSuccess
+                      ? `Successfully extracted ${conditionCount} condition${conditionCount !== 1 ? "s" : ""}.`
+                      : isUnsupported
+                        ? req.error_message || "This file does not appear to be an EAO conditions document."
+                        : req.error_message || "Unable to extract conditions. The file may be corrupted, scanned as an image, or in an unsupported format.";
+
                     return (
                       <Box
                         key={req.id}
@@ -445,12 +461,10 @@ export default function ExtractedDocumentsPage() {
                               fontWeight="bold"
                               color={isSuccess ? colors.successText : colors.errorText}
                             >
-                              {isSuccess ? "Extraction Complete!" : "Extraction Failed"}
+                              {statusTitle}
                             </Typography>
                             <Typography variant="body2" color="textSecondary" sx={{ fontSize: "0.8rem" }}>
-                              {isSuccess
-                                ? `Successfully extracted ${conditionCount} condition${conditionCount !== 1 ? "s" : ""}.`
-                                : req.error_message || "Unable to extract conditions. The file may be corrupted, scanned as an image, or in an unsupported format."}
+                              {statusMessage}
                             </Typography>
                           </Box>
                         </Box>

--- a/condition-web/src/components/ExtractedDocuments/ExtractedDocumentsPage.tsx
+++ b/condition-web/src/components/ExtractedDocuments/ExtractedDocumentsPage.tsx
@@ -28,6 +28,7 @@ import { notify } from "@/components/Shared/Snackbar/snackbarStore";
 import { useGetAllProjects } from "@/hooks/api/useProjects";
 import {
   ExtractionRequest,
+  UnsupportedCategory,
   useGetExtractionRequests,
   useImportExtractionRequest,
   useRejectExtractionRequest,
@@ -85,6 +86,29 @@ interface SectionHeaderProps {
   textColor?: string;
   chevronColor?: string;
 }
+
+const unsupportedDisplayText: Record<UnsupportedCategory, { title: string; message: string }> = {
+  amendment_document: {
+    title: "Amendment Document",
+    message: "Amendment documents are not supported for condition extraction.",
+  },
+  invalid_document: {
+    title: "Invalid Document",
+    message: "This document is not related to EAO project conditions.",
+  },
+  unreadable_format: {
+    title: "Unreadable Format",
+    message: "No readable text was found in this document.",
+  },
+};
+
+const getUnsupportedDisplayText = (req: ExtractionRequest) => {
+  const category = req.extracted_data?.eligibility?.unsupported_category;
+  if (category && unsupportedDisplayText[category]) {
+    return unsupportedDisplayText[category];
+  }
+  return unsupportedDisplayText.invalid_document;
+};
 
 /** Static header bar rendered at the top of each section panel. */
 const SectionHeader: React.FC<SectionHeaderProps> = ({
@@ -403,15 +427,16 @@ export default function ExtractedDocumentsPage() {
                     const isSuccess = req.status === "completed";
                     const isUnsupported = req.status === "unsupported";
                     const conditionCount = req.extracted_data?.conditions?.length ?? 0;
+                    const unsupportedText = getUnsupportedDisplayText(req);
                     const statusTitle = isSuccess
                       ? "Extraction Complete!"
                       : isUnsupported
-                        ? "Unsupported Document"
+                        ? unsupportedText.title
                         : "Extraction Failed";
                     const statusMessage = isSuccess
                       ? `Successfully extracted ${conditionCount} condition${conditionCount !== 1 ? "s" : ""}.`
                       : isUnsupported
-                        ? req.error_message || "This file does not appear to be an EAO conditions document."
+                        ? unsupportedText.message
                         : req.error_message || "Unable to extract conditions. The file may be corrupted, scanned as an image, or in an unsupported format.";
 
                     return (

--- a/condition-web/src/hooks/api/useExtractionRequests.ts
+++ b/condition-web/src/hooks/api/useExtractionRequests.ts
@@ -19,8 +19,19 @@ export interface ExtractedSubcondition {
     subconditions?: ExtractedSubcondition[] | null;
 }
 
+export type UnsupportedCategory =
+    | "amendment_document"
+    | "invalid_document"
+    | "unreadable_format";
+
+export interface ExtractionEligibility {
+    unsupported_category?: UnsupportedCategory | null;
+    [key: string]: unknown;
+}
+
 export interface ExtractedData {
     conditions?: ExtractedCondition[];
+    eligibility?: ExtractionEligibility | null;
     [key: string]: unknown;
 }
 

--- a/condition-web/src/hooks/api/useExtractionRequests.ts
+++ b/condition-web/src/hooks/api/useExtractionRequests.ts
@@ -24,6 +24,15 @@ export interface ExtractedData {
     [key: string]: unknown;
 }
 
+export type ExtractionRequestStatus =
+    | "pending"
+    | "processing"
+    | "completed"
+    | "failed"
+    | "unsupported"
+    | "imported"
+    | "rejected";
+
 export interface ExtractionRequest {
     id: number;
     project_id: string;
@@ -33,7 +42,7 @@ export interface ExtractionRequest {
     original_file_name?: string | null;
     s3_url: string;
     file_size_bytes?: number | null;
-    status: string;
+    status: ExtractionRequestStatus;
     error_message?: string | null;
     extracted_data?: ExtractedData | null;
     created_date: string;

--- a/deployment/charts/condition-cron/templates/configmap.yaml
+++ b/deployment/charts/condition-cron/templates/configmap.yaml
@@ -15,3 +15,4 @@ data:
   S3_REGION: "{{ .Values.s3.region }}"
   S3_SERVICE: "{{ .Values.s3.service }}"
   EXTRACTOR_API_URL: "{{ .Values.extractor.apiUrl }}"
+  EXTRACTION_UNSUPPORTED_CONFIDENCE_THRESHOLD: "{{ .Values.extractor.unsupportedConfidenceThreshold }}"

--- a/deployment/charts/condition-cron/templates/deployment.yaml
+++ b/deployment/charts/condition-cron/templates/deployment.yaml
@@ -95,6 +95,11 @@ spec:
                 configMapKeyRef:
                   name: {{ .Values.name }}-config
                   key: EXTRACTOR_API_URL
+            - name: EXTRACTION_UNSUPPORTED_CONFIDENCE_THRESHOLD
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.name }}-config
+                  key: EXTRACTION_UNSUPPORTED_CONFIDENCE_THRESHOLD
             - name: EXTRACTOR_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/deployment/charts/condition-cron/values.yaml
+++ b/deployment/charts/condition-cron/values.yaml
@@ -32,6 +32,7 @@ s3:
 
 extractor:
   apiUrl: ""
+  unsupportedConfidenceThreshold: "0.75"
 
 secrets:
   s3AccessKeyId: ""


### PR DESCRIPTION

- Add a fail-open eligibility check before condition extraction.
- Mark high-confidence unsupported files, including amendments, as unsupported.
- Show unsupported requests clearly in the web review queue.

