### PR TITLE
CR-162:New roles and groups for condition repo

### DIFF
--- a/condition-web/src/components/ConditionDetails/ConditionAttribute/index.tsx
+++ b/condition-web/src/components/ConditionDetails/ConditionAttribute/index.tsx
@@ -23,6 +23,7 @@ import { useRemoveConditionAttributes } from "@/hooks/api/useConditionAttribute"
 import { notify } from "@/components/Shared/Snackbar/snackbarStore";
 import { useQueryClient } from "@tanstack/react-query";
 import { QUERY_KEY } from "@/hooks/api/constants";
+import { useHasAllowedRoles, KeycloakRoles } from "@/hooks/useAuthorization";
 
 type ConditionAttributeProps = {
     condition: ConditionModel;
@@ -34,6 +35,7 @@ const ConditionAttribute = memo(({
     setCondition,
   }: ConditionAttributeProps) => {
     const queryClient = useQueryClient();
+    const canManage = useHasAllowedRoles([KeycloakRoles.MANAGE_CONDITIONS]);
     const [requiresPlan, setRequiresPlan] = useState<boolean>(
         condition.requires_management_plan || false);
     const [modalOpen, setModalOpen] = useState(false);
@@ -178,13 +180,13 @@ const ConditionAttribute = memo(({
                             value="true"
                             control={<Radio />}
                             label="Yes"
-                            disabled={condition?.is_condition_attributes_approved || false}
+                            disabled={!canManage || (condition?.is_condition_attributes_approved || false)}
                         />
                         <FormControlLabel
                             value="false"
                             control={<Radio />}
                             label="No"
-                            disabled={condition?.is_condition_attributes_approved || false}
+                            disabled={!canManage || (condition?.is_condition_attributes_approved || false)}
                         />
                     </RadioGroup>
                 </FormControl>

--- a/condition-web/src/components/ConditionDetails/ConditionHeader.tsx
+++ b/condition-web/src/components/ConditionDetails/ConditionHeader.tsx
@@ -269,8 +269,9 @@ const ConditionHeader = ({
                             variant="outlined"
                             fullWidth
                             value={conditionName}
-                            onChange={(e) => setConditionName(e.target.value)}
+                            onChange={(e) => canManage && setConditionName(e.target.value)}
                             placeholder="Enter condition name"
+                            disabled={!canManage}
                             size="small"
                             sx={{
                               "& .MuiOutlinedInput-root": {
@@ -371,7 +372,7 @@ const ConditionHeader = ({
                   This condition number already exists. Please enter a new one.
                 </Box>
               )}
-              {(!conditionName || approvalError) && (
+              {((!conditionName && canManage) || approvalError) && (
                 <Box
                   sx={{
                     display: "flex",


### PR DESCRIPTION
Summary:
Disable editing for viewer-only users
Changes:
- Disable "Does this condition require one or more Management Plan(s)?" radio buttons for users without MANAGE_CONDITIONS role
- Disable condition name TextField (empty state) for viewer-only users and hide the "Please enter a Condition Name." validation message