### PR TITLE
CR-143:Condition saving to an Amendment with same number despite error message

### DIFF
--- a/condition-web/src/components/ConditionDetails/ConditionHeader.tsx
+++ b/condition-web/src/components/ConditionDetails/ConditionHeader.tsx
@@ -559,6 +559,7 @@ const ConditionHeader = ({
                         variant="contained"
                         color="primary"
                         size="small"
+                        disabled={editConditionMode}
                         sx={{ padding: "4px 8px", borderRadius: "4px" }}
                         onClick={() => approveTags(true)}
                     >

--- a/condition-web/src/components/ConditionDetails/ConditionHeader.tsx
+++ b/condition-web/src/components/ConditionDetails/ConditionHeader.tsx
@@ -366,7 +366,8 @@ const ConditionHeader = ({
                     flexDirection: "row",
                     marginBottom: "15px",
                     color: "#CE3E39",
-                    marginTop: "-20px",
+                    marginTop: 1,
+                    fontSize: "14px",
                   }}
                 >
                   This condition number already exists. Please enter a new one.


### PR DESCRIPTION
### Summary
- Disabled the Approve Condition Information button while the condition name/number is in edit mode to prevent approving unsaved changes.
- Fixed the "This condition number already exists" error message not being visible — it was hidden behind adjacent elements due to a negative marginTop: "-20px". Changed to marginTop: 1 with consistent fontSize: "14px" styling.