### PR TITLE
CR-185:Ability to Discard a failed extraction

### DIFF
--- a/condition-web/src/components/ExtractedDocuments/ExtractedDocumentsPage.tsx
+++ b/condition-web/src/components/ExtractedDocuments/ExtractedDocumentsPage.tsx
@@ -164,10 +164,10 @@ export default function ExtractedDocumentsPage() {
     });
   };
 
-  const handleReject = (id: number) => {
+  const handleReject = (id: number, successMessage = "Extraction rejected successfully!") => {
     rejectMutation.mutate(id, {
       onSuccess: () => {
-        notify.success("Extraction rejected successfully!");
+        notify.success(successMessage);
         setPreviewRequest(null);
         setStopRequest(null);
         setDiscardRequest(null);
@@ -347,7 +347,7 @@ export default function ExtractedDocumentsPage() {
           </Button>
           <Button
             variant="contained"
-            onClick={() => discardRequest && handleReject(discardRequest.id)}
+            onClick={() => discardRequest && handleReject(discardRequest.id, "Extraction discarded successfully!")}
             disabled={rejectMutation.isPending}
           >
             Confirm


### PR DESCRIPTION
**Changes**:
Updated the discard success toast to show "Extraction discarded successfully!" instead of the generic "Extraction rejected successfully!" for the Discard File flow.