### PR TITLE
CR-159:UI for condition extractor

### DIFF
--- a/condition-web/src/components/ExtractedDocuments/ExtractionPreviewModal.tsx
+++ b/condition-web/src/components/ExtractedDocuments/ExtractionPreviewModal.tsx
@@ -351,17 +351,13 @@ export const ExtractionPreviewModal: React.FC<ExtractionPreviewModalProps> = ({
             </Typography>
 
             <TableContainer component={Paper} variant="outlined" sx={{ borderRadius: 1, maxHeight: '50vh' }}>
-              <Table size="small" stickyHeader>
+              <Table size="small" stickyHeader sx={{ tableLayout: "fixed" }}>
                 <TableHead>
                   <TableRow>
-                    {["", "Condition #", "Condition Name", "Tags"].map((header) => (
-                      <TableCell
-                        key={header}
-                        sx={{ fontWeight: "bold", color: colors.tableHeaderText, whiteSpace: "nowrap" }}
-                      >
-                        {header}
-                      </TableCell>
-                    ))}
+                    <TableCell sx={{ width: 48, fontWeight: "bold", color: colors.tableHeaderText }} />
+                    <TableCell sx={{ width: 120, fontWeight: "bold", color: colors.tableHeaderText, whiteSpace: "nowrap" }}>Condition #</TableCell>
+                    <TableCell sx={{ fontWeight: "bold", color: colors.tableHeaderText }}>Condition Name</TableCell>
+                    <TableCell sx={{ width: "35%", fontWeight: "bold", color: colors.tableHeaderText }}>Tags</TableCell>
                   </TableRow>
                 </TableHead>
                 <TableBody>


### PR DESCRIPTION
Fix: Condition Name column shifting on row expand in Review Extracted Conditions modal

Set table-layout: fixed on the conditions table and added explicit widths to header cells so column widths are stable when the expand/collapse row renders. Previously, the browser recalculated column widths on each expand due to the default table-layout: auto.