### PR TITLE
CR-143:Condition saving to an Amendment with same number despite error message

### DIFF
--- a/condition-web/src/components/ConditionDetails/ConditionHeader.tsx
+++ b/condition-web/src/components/ConditionDetails/ConditionHeader.tsx
@@ -95,7 +95,7 @@ const ConditionHeader = ({
 
         const data: PartialUpdateTopicTagsModel = {};
 
-        if (conditionNumber !== condition.condition_number) {
+        if (Number(conditionNumber) !== Number(condition.condition_number)) {
             data.condition_number = conditionNumber ? Number(conditionNumber) : condition.condition_number;
         }
 


### PR DESCRIPTION
Fix condition number revert conflict error
- Strict type comparison ("10" !== 10) caused a false conflict when reverting a condition number to its original value. Fixed by comparing both sides as numbers.