### PR TITLE
CR-188:Manual add condition - Year Condition Issued displaying as 0

### DIFF
--- a/condition-api/src/condition_api/services/document_service.py
+++ b/condition-api/src/condition_api/services/document_service.py
@@ -326,18 +326,21 @@ class DocumentService:
         )
 
         if is_amendment_document:
-            document = (
+            amendment_detail = (
                 db.session.query(
                     Project.project_name.label('project_name'),
                     DocumentCategory.id.label('document_category_id'),
-                    DocumentCategory.category_name.label('document_category')
+                    DocumentCategory.category_name.label('document_category'),
+                    extract("year", Amendment.date_issued).label('year_issued')
                 )
                 .outerjoin(Document, Document.project_id == Project.project_id)
                 .outerjoin(DocumentTypeModel, DocumentTypeModel.id == Document.document_type_id)
                 .outerjoin(DocumentCategory, DocumentCategory.id == DocumentTypeModel.document_category_id)
+                .outerjoin(Amendment, Amendment.amended_document_id == document_id)
                 .filter(Document.id == is_amendment_document.document_id)
                 .first()
             )
+            document = amendment_detail
         else:
             # Fetch the original document
             document = (
@@ -347,7 +350,8 @@ class DocumentService:
                     DocumentCategory.category_name.label('document_category'),
                     Document.document_id.label('document_id'),
                     Document.document_label.label('document_label'),
-                    DocumentTypeModel.id.label('document_type_id')
+                    DocumentTypeModel.id.label('document_type_id'),
+                    extract("year", Document.date_issued).label('year_issued')
                 )
                 .outerjoin(Project, Project.project_id == Document.project_id)
                 .outerjoin(DocumentTypeModel, DocumentTypeModel.id == Document.document_type_id)
@@ -376,6 +380,7 @@ class DocumentService:
                 is_amendment_document.document_type_id
                 if is_amendment_document else document.document_type_id
             ),
+            "year_issued": int(document.year_issued) if document.year_issued else None,
         }
 
     @staticmethod

--- a/condition-web/src/components/ConditionDetails/CreateCondition/index.tsx
+++ b/condition-web/src/components/ConditionDetails/CreateCondition/index.tsx
@@ -44,6 +44,7 @@ type CreateConditionProps = {
   documentId: string;
   projectName: string;
   documentLabel: string;
+  yearIssued?: number;
   initialCondition?: ConditionModel;
 };
 
@@ -52,13 +53,14 @@ export const CreateConditionPage = ({
   documentId,
   projectName,
   documentLabel,
+  yearIssued,
   initialCondition,
 }: CreateConditionProps) => {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
 
   const [condition, setCondition] = useState<ConditionModel>(
-    initialCondition || createDefaultCondition());
+    initialCondition || { ...createDefaultCondition(), year_issued: yearIssued ?? 0 });
 
   const [tags, setTags] = useState<string[]>(condition?.topic_tags ?? []);
   const [conditionNumberError, setConditionNumberError] = useState(false);

--- a/condition-web/src/models/Document.ts
+++ b/condition-web/src/models/Document.ts
@@ -79,6 +79,7 @@ export interface DocumentDetailsModel {
   document_id: string;
   document_label: string;
   document_type_id: number;
+  year_issued: number | null;
 }
 
 export interface DocumentLabelModel {

--- a/condition-web/src/routes/_authenticated/_dashboard/conditions/create/project/$projectId/document/$documentId/index.tsx
+++ b/condition-web/src/routes/_authenticated/_dashboard/conditions/create/project/$projectId/document/$documentId/index.tsx
@@ -85,6 +85,7 @@ function CreateConditionRoute() {
               documentId={documentId || ""}
               projectName={documentDetails?.project_name || ""}
               documentLabel={documentDetails?.document_label || ""}
+              yearIssued={documentDetails?.year_issued ?? 0}
               initialCondition={initialCondition}
             />
           </Else>


### PR DESCRIPTION
**Summary**:
Pre-populate Year Condition Issued when adding a new condition

**Changes**:
- "Year Condition Issued" showed 0 when clicking "+ Add Condition" from a document, instead of reflecting the document's actual year
- The get_document_details backend endpoint did not include year_issued — it was never queried for either documents or amendments
- Added extract("year", date_issued) to both the document and amendment branches of get_document_details, and returned year_issued in the response
- Added year_issued to DocumentDetailsModel on the frontend, threaded it through the create condition route as a yearIssued prop, and used it to seed the initial condition state in CreateConditionPage