### PR TITLE
CR-170:Condition extractor UI updates

### DIFF
--- a/condition-web/src/components/Conditions/ConditionTableRow.tsx
+++ b/condition-web/src/components/Conditions/ConditionTableRow.tsx
@@ -43,7 +43,6 @@ export default function ConditionTableRow({
       <TableRow
         key={`row-${condition.condition_number}`}
         sx={{
-          my: 1,
           "&:hover": {
             backgroundColor: BCDesignTokens.surfaceColorMenusHover,
           },
@@ -54,7 +53,9 @@ export default function ConditionTableRow({
             align="left"
             sx={{
               borderBottom: border,
-              p: BCDesignTokens.layoutPaddingXsmall,
+              pt: BCDesignTokens.layoutPaddingXsmall,
+              pb: BCDesignTokens.layoutPaddingSmall,
+              px: BCDesignTokens.layoutPaddingXsmall,
             }}
           >
             {condition.amendment_names ?? "--"}
@@ -64,7 +65,9 @@ export default function ConditionTableRow({
           align="left"
           sx={{
             borderBottom: border,
-            p: BCDesignTokens.layoutPaddingXsmall,
+            pt: BCDesignTokens.layoutPaddingXsmall,
+            pb: BCDesignTokens.layoutPaddingSmall,
+            px: BCDesignTokens.layoutPaddingXsmall,
           }}
         >
           {condition.condition_number ?? "--"}
@@ -73,7 +76,9 @@ export default function ConditionTableRow({
           align="left"
           sx={{
             borderBottom: border,
-            p: BCDesignTokens.layoutPaddingXsmall,
+            pt: BCDesignTokens.layoutPaddingXsmall,
+            pb: BCDesignTokens.layoutPaddingSmall,
+            px: BCDesignTokens.layoutPaddingXsmall,
           }}
         >
           <Link
@@ -106,7 +111,9 @@ export default function ConditionTableRow({
           align="left"
           sx={{
             borderBottom: border,
-            p: BCDesignTokens.layoutPaddingXsmall,
+            pt: BCDesignTokens.layoutPaddingXsmall,
+            pb: BCDesignTokens.layoutPaddingSmall,
+            px: BCDesignTokens.layoutPaddingXsmall,
           }}
         >
           {condition.topic_tags?.join(', ') ?? "--"}
@@ -115,7 +122,9 @@ export default function ConditionTableRow({
           align="left"
           sx={{
             borderBottom: border,
-            p: BCDesignTokens.layoutPaddingXsmall,
+            pt: BCDesignTokens.layoutPaddingXsmall,
+            pb: BCDesignTokens.layoutPaddingSmall,
+            px: BCDesignTokens.layoutPaddingXsmall,
           }}
         >
           {condition.year_issued ?? "--"}
@@ -124,7 +133,9 @@ export default function ConditionTableRow({
           align="left"
           sx={{
             borderBottom: border,
-            p: BCDesignTokens.layoutPaddingXsmall,
+            pt: BCDesignTokens.layoutPaddingXsmall,
+            pb: BCDesignTokens.layoutPaddingSmall,
+            px: BCDesignTokens.layoutPaddingXsmall,
           }}
         >
           {condition.source_document ?? "--"}
@@ -133,7 +144,9 @@ export default function ConditionTableRow({
           align="left"
           sx={{
             borderBottom: border,
-            p: BCDesignTokens.layoutPaddingXsmall,
+            pt: BCDesignTokens.layoutPaddingXsmall,
+            pb: BCDesignTokens.layoutPaddingSmall,
+            px: BCDesignTokens.layoutPaddingXsmall,
           }}
         >
           {condition.is_standard_condition ?? "--"}
@@ -142,22 +155,13 @@ export default function ConditionTableRow({
           align="left"
           sx={{
             borderBottom: border,
-            p: BCDesignTokens.layoutPaddingXsmall,
+            pt: BCDesignTokens.layoutPaddingXsmall,
+            pb: BCDesignTokens.layoutPaddingSmall,
+            px: BCDesignTokens.layoutPaddingXsmall,
           }}
         >
           <DocumentStatusChip status={String(condition.is_approved) as DocumentStatus} />
         </TableCell>
-      </TableRow>
-      <TableRow key={`empty-row-${condition.condition_number}`} sx={{ py: 1 }}>
-        <TableCell
-          component="th"
-          scope="row"
-          colSpan={12}
-          sx={{
-            border: 0,
-            py: BCDesignTokens.layoutPaddingXsmall,
-          }}
-        />
       </TableRow>
     </>
   );

--- a/condition-web/src/components/Documents/DocumentEntryForm.tsx
+++ b/condition-web/src/components/Documents/DocumentEntryForm.tsx
@@ -252,13 +252,8 @@ export const DocumentEntryForm = ({
                 <Typography variant="caption" color="text.secondary" display="block">
                     {transferData
                         ? "The document details have been populated from your previous entry. You can edit any field if needed."
-                        : "Manually register a document and its details into the system."}
+                        : "Manually enter a document and its details into the system."}
                 </Typography>
-                {!transferData && (
-                    <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 0.5 }}>
-                        <strong>Note:</strong> Use this option for amendments and documents that cannot be extracted automatically.
-                    </Typography>
-                )}
             </Box>
         <Box
             display="flex"

--- a/condition-web/src/components/Documents/DocumentTableRow.tsx
+++ b/condition-web/src/components/Documents/DocumentTableRow.tsx
@@ -37,7 +37,9 @@ function DocumentRow({ projectId, document, isAmendment }: { projectId: string; 
         align="left"
         sx={{
           borderBottom: border,
-          padding: BCDesignTokens.layoutPaddingXsmall,
+          pt: BCDesignTokens.layoutPaddingXsmall,
+          pb: BCDesignTokens.layoutPaddingSmall,
+          px: BCDesignTokens.layoutPaddingXsmall,
           paddingLeft: isAmendment ? 6 : BCDesignTokens.layoutPaddingXsmall,
           width: '50%',
         }}
@@ -67,7 +69,9 @@ function DocumentRow({ projectId, document, isAmendment }: { projectId: string; 
         align="right"
         sx={{
           borderBottom: border,
-          padding: BCDesignTokens.layoutPaddingXsmall,
+          pt: BCDesignTokens.layoutPaddingXsmall,
+          pb: BCDesignTokens.layoutPaddingSmall,
+          px: BCDesignTokens.layoutPaddingXsmall,
           width: '25%',
         }}
       >
@@ -77,7 +81,9 @@ function DocumentRow({ projectId, document, isAmendment }: { projectId: string; 
         align="right"
         sx={{
           borderBottom: border,
-          padding: BCDesignTokens.layoutPaddingXsmall,
+          pt: BCDesignTokens.layoutPaddingXsmall,
+          pb: BCDesignTokens.layoutPaddingSmall,
+          px: BCDesignTokens.layoutPaddingXsmall,
           width: '25%',
         }}
       >
@@ -99,9 +105,6 @@ export default function DocumentTableRow({ projectId, document, amendments }: Do
           isAmendment
         />
       ))}
-      <TableRow key={`empty-row-${document.document_id}`}>
-        <TableCell colSpan={12} sx={{ border: 0, py: BCDesignTokens.layoutPaddingXsmall }} />
-      </TableRow>
     </>
   );
 }

--- a/condition-web/src/components/Projects/DocumentTableRow.tsx
+++ b/condition-web/src/components/Projects/DocumentTableRow.tsx
@@ -36,7 +36,8 @@ export default function DocumentTableRow({
           align="left"
           sx={{
             borderBottom: border,
-            py: BCDesignTokens.layoutPaddingXsmall,
+            pt: BCDesignTokens.layoutPaddingXsmall,
+            pb: BCDesignTokens.layoutPaddingSmall,
             paddingLeft: BCDesignTokens.layoutPaddingXsmall,
             width: '40%',
           }}
@@ -66,7 +67,8 @@ export default function DocumentTableRow({
           align="right"
           sx={{
             borderBottom: border,
-            py: BCDesignTokens.layoutPaddingXsmall,
+            pt: BCDesignTokens.layoutPaddingXsmall,
+            pb: BCDesignTokens.layoutPaddingSmall,
             width: '20%',
           }}
         >
@@ -76,7 +78,8 @@ export default function DocumentTableRow({
           align="right"
           sx={{
             borderBottom: border,
-            py: BCDesignTokens.layoutPaddingXsmall,
+            pt: BCDesignTokens.layoutPaddingXsmall,
+            pb: BCDesignTokens.layoutPaddingSmall,
             width: '20%',
           }}
         >
@@ -86,7 +89,8 @@ export default function DocumentTableRow({
           align="right"
           sx={{
             borderBottom: border,
-            py: BCDesignTokens.layoutPaddingXsmall,
+            pt: BCDesignTokens.layoutPaddingXsmall,
+            pb: BCDesignTokens.layoutPaddingSmall,
             paddingRight: BCDesignTokens.layoutPaddingXsmall,
             width: '20%',
           }}
@@ -95,17 +99,6 @@ export default function DocumentTableRow({
             status={document.status === null ? "nodata" : String(document.status) as DocumentStatus}
           />
         </TableCell>
-      </TableRow>
-      <TableRow key={`empty-row-${document.document_id}`} sx={{ py: 1 }}>
-        <TableCell
-          component="th"
-          scope="row"
-          colSpan={12}
-          sx={{
-            border: 0,
-            py: BCDesignTokens.layoutPaddingXsmall,
-          }}
-        />
       </TableRow>
     </>
   );


### PR DESCRIPTION
Changes:
- Fix table row hover height by removing empty spacer <tr> rows and absorbing their spacing as increased cell bottom padding
- Change helper text from "Manually register a document and its details into the system" to "Manually enter a document and its details into the system"
- Remove the note "Use this option for amendments and documents that cannot be extracted automatically"