### PR TITLE
CR-190:Document label not saving upon change

### DIFF
--- a/condition-web/src/hooks/api/useDocuments.tsx
+++ b/condition-web/src/hooks/api/useDocuments.tsx
@@ -8,7 +8,7 @@ import {
   ProjectDocumentAllAmendmentsModel
 } from "@/models/Document";
 import { submitRequest } from "@/utils/axiosUtils";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMutation } from "@tanstack/react-query";
 import { Options } from "./types";
 import { notify } from "@/components/Shared/Snackbar/snackbarStore";
@@ -165,6 +165,7 @@ export const useUpdateDocument = (
   documentId?: string,
   options?: Options
 ) => {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (documentLabel: string) => {
       if (!documentId) {
@@ -175,6 +176,9 @@ export const useUpdateDocument = (
     },
     onSuccess: (updatedDocument) => {
       notify.success("Document name updated successfully!");
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY.DOCUMENTDETAIL, documentId] });
+      queryClient.removeQueries({ queryKey: [QUERY_KEY.PROJECTDOCUMENT] });
+      queryClient.removeQueries({ queryKey: [QUERY_KEY.DOCUMENT] });
 
       if (options?.onSuccess) {
         options.onSuccess(updatedDocument); // Pass the updated document back

--- a/condition-web/src/routes/_authenticated/_dashboard/conditions/project/$projectId/document/$documentId/index.tsx
+++ b/condition-web/src/routes/_authenticated/_dashboard/conditions/project/$projectId/document/$documentId/index.tsx
@@ -55,15 +55,19 @@ function ConditionPage() {
   useEffect(() => {
     if (documentDetails) {
       setDocumentLabel(documentDetails.document_label || "Document Label");
+    }
+  }, [documentDetails]);
 
+  useEffect(() => {
+    if (documentDetails) {
       setBreadcrumbs([
         { title: "Home", path: "/projects", clickable: true },
         { title: documentDetails?.project_name || "", path: `/projects/${projectId}`, clickable: true },
         { title: documentDetails?.document_category || "", path: `/documents/project/${projectId}/document-category/${documentDetails.document_category_id}/`, clickable: true },
-        { title: documentDetails?.document_label || "", path: undefined, clickable: false }
+        { title: documentLabel || "", path: undefined, clickable: false }
       ]);
     }
-  }, [documentDetails, projectId, setBreadcrumbs]);
+  }, [documentDetails, documentLabel, projectId, setBreadcrumbs]);
 
   const handleDocumentLabelChange = (newLabel: string) => {
     setDocumentLabel(newLabel);


### PR DESCRIPTION
**Summary**:

After updating a document label, the breadcrumb on the conditions page and the document list on the category page were not reflecting the new name.
**Changes**:
Breadcrumb now reacts to local documentLabel state changes (not just the query data) so it updates immediately on save
useUpdateDocument now invalidates the DOCUMENTDETAIL cache and removes the DOCUMENT/PROJECTDOCUMENT caches on success — removeQueries is used instead of invalidateQueries to bypass the refetchOnMount: false setting, ensuring fresh data is fetched when navigating back