### PR TITLE
CR-143:Condition saving to an Amendment with same number despite error message

### DIFF
--- a/condition-web/src/components/ConditionDetails/ConditionHeader.tsx
+++ b/condition-web/src/components/ConditionDetails/ConditionHeader.tsx
@@ -125,6 +125,7 @@ const ConditionHeader = ({
           }
         } else {
           setEditConditionMode(false);
+          setConditionConflictError(false);
         }
     };
 


### PR DESCRIPTION
Changes:
- After reverting to the original condition number and saving, the "condition number already exists" error remained visible. Added setConditionConflictError(false) to the no-change branch so the error clears on save.