### PR TITLE
CR-149:Incorrect Default Selection for “Submitted to EAO for” Condition

### DIFF
--- a/batch_api_calling/extract_management_plans.py
+++ b/batch_api_calling/extract_management_plans.py
@@ -75,9 +75,9 @@ def extract_management_plan_info_using_gpt(condition_text):
                         "description": "The name of the plan/report/proposal/etc. that the condition is requiring to be written. E.g. Air Quality Mitigation and Monitoring Plan, Marine Water Quality Management and Monitoring Plan for Operations, etc. Write it in title case (E.g. The Catcher in the Rye)."
                       },
                       "approval_type": {
-                        "type": "string", 
-                        "enum": ["Acceptance", "Satisfaction", "Other"],
-                        "description": "If the plan/report/proposal/etc. is explicitly stated to be to either the \"acceptance\" of or to the \"satisfaction\" of the Environmental Assessment Office (EAO). Is Other if not Satisfaction or Acceptance or if not specified."
+                        "type": "string",
+                        "enum": ["Review", "Acceptance", "Satisfaction", "Approval", "Other"],
+                        "description": "The type of approval required when the plan/report/proposal/etc. is submitted to the EAO. Focus only on the clause describing the submission of the document itself — not clauses about how the plan must be implemented or carried out. Use \"Review\" if the submission clause indicates the document is provided for the EAO to review, or if no specific approval standard is mentioned — this is the default. Use \"Acceptance\" only if the submission clause explicitly requires the document to meet the EAO's acceptance standard. Use \"Satisfaction\" only if the submission clause explicitly requires the document to meet the EAO's satisfaction standard. Use \"Approval\" if the submission clause requires the document to be approved by the EAO. Use \"Other\" for any other explicit approval language. Many conditions include boilerplate language about implementation being to a regulator's standard — do not use that language to determine this field."
                       },
                       "stakeholders_to_consult": {
                         "type": "array",

--- a/condition-parser/extract_management_plans.py
+++ b/condition-parser/extract_management_plans.py
@@ -90,9 +90,9 @@ def extract_management_plan_info_using_gpt(condition_text):
                         "description": "Whether or not the deliverable is a \"Plan\" document (e.g., Management Plan, Monitoring Plan, Mitigation Plan, etc.). False if not specified."
                       },
                       "approval_type": {
-                        "type": "string", 
-                        "enum": ["Acceptance", "Satisfaction"],
-                        "description": "If the plan/report/proposal/etc. is explicitly stated to be to either the \"acceptance\" of or to the \"satisfaction\" of the Environmental Assessment Office (EAO). Is null if not specified."
+                        "type": "string",
+                        "enum": ["Review", "Acceptance", "Satisfaction", "Approval", "Other"],
+                        "description": "The type of approval required when the plan/report/proposal/etc. is submitted to the EAO. Focus only on the clause describing the submission of the document itself — not clauses about how the plan must be implemented or carried out. Use \"Review\" if the submission clause indicates the document is provided for the EAO to review, or if no specific approval standard is mentioned — this is the default. Use \"Acceptance\" only if the submission clause explicitly requires the document to meet the EAO's acceptance standard. Use \"Satisfaction\" only if the submission clause explicitly requires the document to meet the EAO's satisfaction standard. Use \"Approval\" if the submission clause requires the document to be approved by the EAO. Use \"Other\" for any other explicit approval language. Many conditions include boilerplate language about implementation being to a regulator's standard — do not use that language to determine this field."
                       },
                       "stakeholders_to_consult": {
                         "type": "array",

--- a/condition-parser/schemas/enrichment_schema.json
+++ b/condition-parser/schemas/enrichment_schema.json
@@ -72,8 +72,8 @@
               },
               "approval_type": {
                 "type": "string",
-                "enum": ["Acceptance", "Satisfaction"],
-                "description": "Whether the document must be to the 'acceptance' or 'satisfaction' of the EAO. Null if not specified."
+                "enum": ["Review", "Acceptance", "Satisfaction", "Approval", "Other"],
+                "description": "The type of approval required when the plan/report/proposal/etc. is submitted to the EAO. Focus only on the clause describing the submission of the document itself — not clauses about how the plan must be implemented or carried out. Use \"Review\" if the submission clause indicates the document is provided for the EAO to review, or if no specific approval standard is mentioned — this is the default. Use \"Acceptance\" only if the submission clause explicitly requires the document to meet the EAO's acceptance standard. Use \"Satisfaction\" only if the submission clause explicitly requires the document to meet the EAO's satisfaction standard. Use \"Approval\" if the submission clause requires the document to be approved by the EAO. Use \"Other\" for any other explicit approval language. Many conditions include boilerplate language about implementation being to a regulator's standard — do not use that language to determine this field."
               },
               "stakeholders_to_consult": {
                 "type": "array",


### PR DESCRIPTION
**Summary**
The approval_type field on deliverables was incorrectly defaulting to "Satisfaction" because the model was reading boilerplate implementation language ("shall be implemented to the satisfaction of the EAO") instead of the actual submission clause.

**Root causes:**

The old enum only contained ["Acceptance", "Satisfaction"], so the model was forced into one of those two values even when the submission clause said "for review" or "for approval"
The description gave no guidance on which clause to look at, causing the model to pick up on ubiquitous implementation boilerplate
Changes across all three extraction files (enrichment_schema.json, condition-parser/extract_management_plans.py, batch_api_calling/extract_management_plans.py):

Expanded the enum from ["Acceptance", "Satisfaction"] to ["Review", "Acceptance", "Satisfaction", "Approval", "Other"] — adding "Review" as the first/default value and "Approval" to handle conditions that require EAO approval
Updated the description to explicitly instruct the model to focus only on the submission clause (e.g., "provide to the EAO for review"), and to ignore implementation clauses ("implemented to the satisfaction of")