### PR TITLE
CR-192:Empty project shells appearing on Projects page

### DIFF
--- a/condition-api/src/condition_api/services/extraction_request_service.py
+++ b/condition-api/src/condition_api/services/extraction_request_service.py
@@ -169,6 +169,21 @@ class ExtractionRequestService:
                 if document:
                     document.is_active = False
 
+                    if document.project_id:
+                        other_active = (
+                            db.session.query(Document)
+                            .filter(
+                                Document.project_id == document.project_id,
+                                Document.document_id != req.document_id,
+                                Document.is_active == True,  # noqa: E712
+                            )
+                            .first()
+                        )
+                        if not other_active:
+                            project = db.session.query(Project).filter_by(project_id=document.project_id).first()
+                            if project:
+                                project.is_active = False
+
             db.session.commit()
         except SQLAlchemyError as exc:
             db.session.rollback()


### PR DESCRIPTION
Change:
Deactivate project when last active document is discarded

Details: 
When an extraction is discarded, if the associated document is the last active document on its project, the project's is_active flag is also set to False. Both updates are committed in the same transaction and rolled back together on failure.