### PR TITLE
CR-196:Mapping Document Type to EPIC.public

### DIFF
--- a/condition-api/src/condition_api/schemas/extraction_request.py
+++ b/condition-api/src/condition_api/schemas/extraction_request.py
@@ -10,6 +10,8 @@ class ExtractionRequestSchema(Schema):
     document_id = fields.Str(allow_none=True)
     document_type_id = fields.Int(allow_none=True)
     document_label = fields.Str(allow_none=True)
+    date_issued = fields.Str(allow_none=True)
+    act = fields.Int(allow_none=True)
     original_file_name = fields.Str(allow_none=True)
     s3_url = fields.Str(required=True)
     file_size_bytes = fields.Int(allow_none=True)

--- a/condition-api/src/condition_api/schemas/project.py
+++ b/condition-api/src/condition_api/schemas/project.py
@@ -22,6 +22,7 @@ class ProjectSchema(BaseSchema):
 
     project_id = fields.Str(data_key="project_id")
     project_name = fields.Str(data_key="project_name")
+    project_type = fields.Str(data_key="project_type", allow_none=True)
     is_active = fields.Bool(data_key="is_active")
 
     # A project can have multiple documents

--- a/condition-api/src/condition_api/services/extraction_request_service.py
+++ b/condition-api/src/condition_api/services/extraction_request_service.py
@@ -52,12 +52,32 @@ class ExtractionRequestService:
         )
         db.session.add(request)
 
-        # Activate the document so it appears in the repository immediately
+        # Activate the document (create it first if it doesn't exist in the DB)
         document_id = data.get('document_id')
         if document_id:
             document = db.session.query(Document).filter_by(document_id=document_id).first()
-            if document:
-                document.is_active = True
+            if not document:
+                raw_date = data.get('date_issued')
+                parsed_date = None
+                if raw_date:
+                    try:
+                        parsed_date = datetime.strptime(raw_date[:10], '%Y-%m-%d').date()
+                    except ValueError:
+                        logger.warning("Could not parse date_issued '%s' for document_id=%s", raw_date, document_id)
+
+                document = Document(
+                    document_id=document_id,
+                    project_id=data['project_id'],
+                    document_type_id=data.get('document_type_id'),
+                    document_label=data.get('document_label'),
+                    date_issued=parsed_date,
+                    act=data.get('act'),
+                    is_active=False,
+                )
+                db.session.add(document)
+                logger.info("Created new document document_id=%s from extraction request", document_id)
+
+            document.is_active = True
 
         # Activate the project so it is visible in the repository
         project = db.session.query(Project).filter_by(project_id=data['project_id']).first()

--- a/condition-api/src/condition_api/services/project_service.py
+++ b/condition-api/src/condition_api/services/project_service.py
@@ -247,7 +247,10 @@ class ProjectService:
             .order_by(Project.project_name)
             .all()
         )
-        return [{"project_id": row.project_id, "project_name": row.project_name, "project_type": row.project_type} for row in projects]
+        return [
+            {"project_id": row.project_id, "project_name": row.project_name, "project_type": row.project_type}
+            for row in projects
+        ]
 
     @staticmethod
     def activate_project(project_id):

--- a/condition-api/src/condition_api/services/project_service.py
+++ b/condition-api/src/condition_api/services/project_service.py
@@ -243,11 +243,11 @@ class ProjectService:
     def get_all_projects_simple():
         """Fetch all projects (active and inactive) as a simple id/name list."""
         projects = (
-            db.session.query(Project.project_id, Project.project_name)
+            db.session.query(Project.project_id, Project.project_name, Project.project_type)
             .order_by(Project.project_name)
             .all()
         )
-        return [{"project_id": row.project_id, "project_name": row.project_name} for row in projects]
+        return [{"project_id": row.project_id, "project_name": row.project_name, "project_type": row.project_type} for row in projects]
 
     @staticmethod
     def activate_project(project_id):

--- a/condition-web/src/components/Documents/DocumentExtractionForm.tsx
+++ b/condition-web/src/components/Documents/DocumentExtractionForm.tsx
@@ -229,7 +229,7 @@ export const DocumentExtractionForm = ({
                             <Link
                                 component="button"
                                 variant="caption"
-                                underline="always"
+                                underline="hover"
                                 onClick={() => setShowAllDocSearch(true)}
                                 sx={{
                                     display: "inline-flex",

--- a/condition-web/src/components/Documents/DocumentExtractionForm.tsx
+++ b/condition-web/src/components/Documents/DocumentExtractionForm.tsx
@@ -8,11 +8,16 @@ import {
     Box,
     Button,
     CircularProgress,
+    IconButton,
+    InputAdornment,
+    Link,
     Stack,
     TextField,
     Tooltip,
     Typography,
 } from "@mui/material";
+import SearchIcon from "@mui/icons-material/Search";
+import CloseIcon from "@mui/icons-material/Close";
 import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
 import UploadFileIcon from "@mui/icons-material/UploadFile";
@@ -20,10 +25,10 @@ import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import InsertDriveFileIcon from "@mui/icons-material/InsertDriveFile";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
 import { BCDesignTokens } from "epic.theme";
-import { DocumentLabelModel, DocumentTypeModel } from "@/models/Document";
+import { DocumentLabelModel, DocumentTypeModel, EaoSearchDocumentResult } from "@/models/Document";
 import { AvailableProjectModel } from "@/models/Project";
 import { useGetAllProjects } from "@/hooks/api/useProjects";
-import { useGetDocumentLabels } from "@/hooks/api/useDocuments";
+import { useGetDocumentLabels, useSearchEaoDocuments } from "@/hooks/api/useDocuments";
 import { S3_FOLDER, useUploadDocument } from "@/hooks/api/useObjectStorage";
 import { useCreateExtractionRequest } from "@/hooks/api/useExtractionRequests";
 import { notify } from "@/components/Shared/Snackbar/snackbarStore";
@@ -43,6 +48,7 @@ export const DocumentExtractionForm = ({
     const [selectedDocumentType, setSelectedDocumentType] = useState<DocumentTypeModel | null>(null);
     const [selectedDisplayName, setSelectedDisplayName] = useState<DocumentLabelModel | null>(null);
     const [showMore, setShowMore] = useState(false);
+    const [showAllDocSearch, setShowAllDocSearch] = useState(false);
 
     const { data: documentLabels = [], isPending: isLabelsLoading } = useGetDocumentLabels(
         selectedProject?.project_id,
@@ -51,6 +57,11 @@ export const DocumentExtractionForm = ({
     const [uploadedFile, setUploadedFile] = useState<File | null>(null);
     const [s3Key, setS3Key] = useState<string | null>(null);
     const [uploadSuccess, setUploadSuccess] = useState(false);
+
+    const { data: eaoResults = [], isFetching: isEaoLoading } = useSearchEaoDocuments(
+        selectedProject?.project_id,
+        showAllDocSearch
+    );
 
     const uploadDocument = useUploadDocument();
     const createExtractionRequest = useCreateExtractionRequest();
@@ -90,6 +101,8 @@ export const DocumentExtractionForm = ({
                             document_id: selectedDisplayName?.document_id ?? null,
                             document_type_id: selectedDocumentType?.id ?? null,
                             document_label: selectedDisplayName?.document_label ?? null,
+                            date_issued: selectedDisplayName?.date_issued ?? null,
+                            act: selectedDisplayName?.act ?? null,
                             original_file_name: uploadedFile.name,
                             s3_url: s3RelativeUrl,
                             file_size_bytes: uploadedFile.size,
@@ -148,6 +161,7 @@ export const DocumentExtractionForm = ({
                             setSelectedProject(v);
                             setSelectedDocumentType(null);
                             setSelectedDisplayName(null);
+                            setShowAllDocSearch(false);
                         }}
                         renderInput={(params) => (
                             <TextField
@@ -175,6 +189,7 @@ export const DocumentExtractionForm = ({
                             onChange={(_, v) => {
                                 setSelectedDocumentType(v);
                                 setSelectedDisplayName(null);
+                                setShowAllDocSearch(false);
                             }}
                             disabled={!selectedProject}
                             renderInput={(params) => (
@@ -199,6 +214,7 @@ export const DocumentExtractionForm = ({
                             getOptionLabel={(d) => d.document_label ?? ""}
                             onChange={(_, v) => setSelectedDisplayName(v)}
                             disabled={!selectedProject || !selectedDocumentType}
+                            sx={{ "& .MuiFormControl-root": { verticalAlign: "bottom", marginBottom: 0 } }}
                             renderInput={(params) => (
                                 <TextField
                                     {...params}
@@ -209,6 +225,85 @@ export const DocumentExtractionForm = ({
                                 />
                             )}
                         />
+                        {selectedProject && selectedDocumentType && !showAllDocSearch && (
+                            <Link
+                                component="button"
+                                variant="caption"
+                                underline="always"
+                                onClick={() => setShowAllDocSearch(true)}
+                                sx={{
+                                    display: "inline-flex",
+                                    alignItems: "center",
+                                    gap: 0.4,
+                                    cursor: "pointer",
+                                    color: "primary.main",
+                                }}
+                            >
+                                <SearchIcon sx={{ fontSize: 14 }} />
+                                Can't find it? Search all documents
+                            </Link>
+                        )}
+                        {showAllDocSearch && (
+                            <Box mt={1}>
+                                <Autocomplete<EaoSearchDocumentResult>
+                                    sx={{ "& .MuiFormControl-root": { marginBottom: 0 } }}
+                                    options={eaoResults}
+                                    loading={isEaoLoading}
+                                    getOptionLabel={(d) => d.displayName ?? ""}
+                                    isOptionEqualToValue={(a, b) => a._id === b._id}
+                                    renderOption={(props, option) => (
+                                        <li {...props} key={option._id}>
+                                            {option.displayName}
+                                        </li>
+                                    )}
+                                    onChange={(_, v) => {
+                                        if (v) {
+                                            setSelectedDisplayName({
+                                                document_id: v._id,
+                                                document_label: v.displayName,
+                                                date_issued: v.datePosted ? v.datePosted.split("T")[0] : null,
+                                                act: v.legislation ?? null,
+                                                project_type: selectedProject?.project_type ?? null,
+                                            });
+                                            setShowAllDocSearch(false);
+                                        }
+                                    }}
+                                    renderInput={(params) => (
+                                        <TextField
+                                            {...params}
+                                            placeholder="Search all documents…"
+                                            size="small"
+                                            fullWidth
+                                            autoFocus
+                                            InputProps={{
+                                                ...params.InputProps,
+                                                startAdornment: (
+                                                    <>
+                                                        <SearchIcon sx={{ color: "text.secondary", fontSize: 18, mr: 0.5 }} />
+                                                        {params.InputProps.startAdornment}
+                                                    </>
+                                                ),
+                                                endAdornment: (
+                                                    <>
+                                                        {params.InputProps.endAdornment}
+                                                        <InputAdornment position="end">
+                                                            <IconButton
+                                                                size="small"
+                                                                edge="end"
+                                                                onClick={() => setShowAllDocSearch(false)}
+                                                                sx={{ color: "text.secondary" }}
+                                                            >
+                                                                <CloseIcon fontSize="small" />
+                                                            </IconButton>
+                                                        </InputAdornment>
+                                                    </>
+                                                ),
+                                            }}
+                                        />
+                                    )}
+                                />
+                            </Box>
+                        )}
                     </Box>
                 </Box>
 

--- a/condition-web/src/hooks/api/useDocuments.tsx
+++ b/condition-web/src/hooks/api/useDocuments.tsx
@@ -5,9 +5,10 @@ import {
   DocumentLabelModel,
   DocumentModel,
   DocumentDetailsModel,
+  EaoSearchResponse,
   ProjectDocumentAllAmendmentsModel
 } from "@/models/Document";
-import { submitRequest } from "@/utils/axiosUtils";
+import { submitRequest, requestAxios } from "@/utils/axiosUtils";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMutation } from "@tanstack/react-query";
 import { Options } from "./types";
@@ -60,6 +61,56 @@ export const useGetDocumentLabels = (projectId?: string, documentTypeId?: number
     queryFn: () => fetchDocumentLabels(projectId!, documentTypeId),
     enabled: Boolean(projectId && documentTypeId),
     ...defaultUseQueryOptions,
+  });
+};
+
+const EAO_SEARCH_BASE = 'https://projects.eao.gov.bc.ca/api/search';
+
+const EAO_PAGE_SIZE = 1000;
+
+const fetchEaoPage = (projectId: string, pageNum: number) => {
+  const params = new URLSearchParams({
+    dataset: 'Document',
+    pageNum: String(pageNum),
+    pageSize: String(EAO_PAGE_SIZE),
+    projectLegislation: 'default',
+    populate: 'false',
+    fuzzy: 'false',
+    'and[project]': projectId,
+    fields: '',
+  });
+  params.append('sortBy', '+displayName');
+  return requestAxios({ url: `${EAO_SEARCH_BASE}?${params.toString()}`, method: 'get' })
+    .then((data): EaoSearchResponse => {
+      const results: EaoSearchResponse[] = Array.isArray(data) ? data : [data];
+      return results[0];
+    });
+};
+
+const fetchEaoDocuments = async (projectId: string): Promise<EaoSearchDocumentResult[]> => {
+  const first = await fetchEaoPage(projectId, 0);
+  const total = first?.meta?.[0]?.searchResultsTotal ?? 0;
+  const allResults = [...(first?.searchResults ?? [])];
+
+  if (total > EAO_PAGE_SIZE) {
+    const extraPages = Math.ceil((total - EAO_PAGE_SIZE) / EAO_PAGE_SIZE);
+    const pages = await Promise.all(
+      Array.from({ length: extraPages }, (_, i) => fetchEaoPage(projectId, i + 1))
+    );
+    pages.forEach(p => allResults.push(...(p?.searchResults ?? [])));
+  }
+
+  return allResults;
+};
+
+export const useSearchEaoDocuments = (projectId?: string, enabled = false) => {
+  return useQuery({
+    queryKey: ['eao-documents', projectId],
+    queryFn: () => fetchEaoDocuments(projectId!),
+    enabled: Boolean(projectId) && enabled,
+    staleTime: 1000 * 60 * 5,
+    refetchOnWindowFocus: false,
+    retry: false,
   });
 };
 

--- a/condition-web/src/hooks/api/useDocuments.tsx
+++ b/condition-web/src/hooks/api/useDocuments.tsx
@@ -9,6 +9,7 @@ import {
   ProjectDocumentAllAmendmentsModel
 } from "@/models/Document";
 import { submitRequest, requestAxios } from "@/utils/axiosUtils";
+import { AppConfig } from "@/utils/config";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMutation } from "@tanstack/react-query";
 import { Options } from "./types";
@@ -64,7 +65,7 @@ export const useGetDocumentLabels = (projectId?: string, documentTypeId?: number
   });
 };
 
-const EAO_SEARCH_BASE = 'https://projects.eao.gov.bc.ca/api/search';
+const EAO_SEARCH_BASE = AppConfig.eaoSearchUrl;
 
 const EAO_PAGE_SIZE = 1000;
 

--- a/condition-web/src/hooks/api/useProjects.tsx
+++ b/condition-web/src/hooks/api/useProjects.tsx
@@ -34,6 +34,8 @@ export const useGetAllProjects = () => {
     queryKey: [QUERY_KEY.PROJECTS, 'all'],
     queryFn: fetchAllProjects,
     ...defaultUseQueryOptions,
+    staleTime: 0,
+    refetchOnMount: true,
   });
 };
 

--- a/condition-web/src/models/Document.ts
+++ b/condition-web/src/models/Document.ts
@@ -101,3 +101,16 @@ export interface AvailableDocumentModel {
   date_issued: string | null;
   document_type: string | null;
 }
+
+export interface EaoSearchDocumentResult {
+  _id: string;
+  displayName: string;
+  datePosted: string | null;
+  documentType: string | null;
+  legislation: number | null;
+}
+
+export interface EaoSearchResponse {
+  searchResults: EaoSearchDocumentResult[];
+  meta: Array<{ searchResultsTotal: number }>;
+}

--- a/condition-web/src/models/Project.ts
+++ b/condition-web/src/models/Project.ts
@@ -10,4 +10,5 @@ export interface ProjectModel {
 export interface AvailableProjectModel {
   project_id: string;
   project_name: string;
+  project_type?: string | null;
 }

--- a/condition-web/src/utils/config.ts
+++ b/condition-web/src/utils/config.ts
@@ -14,6 +14,7 @@ declare global {
       VITE_SUPPORT_EMAIL: string;
       VITE_OBJECT_STORAGE_URL: string;
       VITE_CONDITION_DOCUMENTS_FOLDER: string;
+      VITE_EAO_SEARCH_URL: string;
     VITE_ENABLE_NEW_SUBMIT_FLOW: string;
     };
   }
@@ -44,11 +45,14 @@ const CONDITION_DOCUMENTS_FOLDER =
   ).trim() || "condition_extraction_documents";
 const ENABLE_NEW_SUBMIT_FLOW =
   (window._env_?.VITE_ENABLE_NEW_SUBMIT_FLOW || import.meta.env.VITE_ENABLE_NEW_SUBMIT_FLOW || "false").toLowerCase() === "true";
+const EAO_SEARCH_URL =
+  window._env_?.VITE_EAO_SEARCH_URL || import.meta.env.VITE_EAO_SEARCH_URL || "https://projects.eao.gov.bc.ca/api/search";
 
 export const AppConfig = {
   apiUrl: `${API_URL}`,
   documentUrl: OBJECT_STORAGE_URL,
   conditionDocumentsFolder: CONDITION_DOCUMENTS_FOLDER,
+  eaoSearchUrl: EAO_SEARCH_URL,
   environment: APP_ENVIRONMENT,
   version: APP_VERSION,
   appTitle: APP_TITLE,


### PR DESCRIPTION
Summary
- Adds a "Can't find it? Search all documents" link below the Document dropdown on the extraction form, visible only after both Project and Document Type are selected
- Clicking the link opens a separate EAO document search control that fetches all documents for the selected project from the public EAO search API (projects.eao.gov.bc.ca), with client-side filtering as the user types
- Selecting a document from the search populates the main Document dropdown and pre-fills act, date_issued, and project_type in "Show document details"
- The EAO search URL is configurable via VITE_EAO_SEARCH_URL env var
- If the selected EAO document does not exist in our DB, the extraction request service creates it automatically following the same pattern as the epic-cron job, so extraction can proceed without a prior sync

Backend changes

- ExtractionRequestSchema — added act and date_issued as accepted load fields
- ExtractionRequestService.create — if the document referenced by document_id is not found in the DB, creates it with document_label, date_issued, act, document_type_id, and project_id before activating it
- ProjectService.get_all_projects_simple / ProjectSchema — now returns project_type so the frontend can populate the field directly from the selected project without a separate lookup
- Removed unused GET /documents/labels (all-projects) endpoint and get_all_document_labels service method

Frontend changes

- DocumentExtractionForm — new EAO search Autocomplete with autoFocus, search icon, and close (✕) button inside the input; document selection maps _id → document_id, displayName → document_label, datePosted → date_issued, legislation → act
- useSearchEaoDocuments hook — fetches all documents for a project using pageSize=1000 per page, paginating automatically if total exceeds 1000
- AvailableProjectModel — added project_type field
- EaoSearchDocumentResult / EaoSearchResponse — new models for the EAO API response shape
- AppConfig.eaoSearchUrl — EAO base URL driven by VITE_EAO_SEARCH_URL env var