### PR TITLE
CR-191:Add new condition' numbering issues

### DIFF
--- a/condition-api/src/condition_api/resources/condition.py
+++ b/condition-api/src/condition_api/resources/condition.py
@@ -90,7 +90,9 @@ class ConditionDetailsPatchResource(Resource):
             conditions_data = ConditionSchema().load(API.payload)
             query_params = request.args
             check_condition_exists = query_params.get('check_condition_exists', 'false', type=str).lower() == 'true'
-            check_condition_over_project = query_params.get('check_condition_over_project', 'false', type=str).lower() == 'true'
+            check_condition_over_project = (
+                query_params.get('check_condition_over_project', 'false', type=str).lower() == 'true'
+            )
             updated_condition = ConditionService.update_condition(
                 conditions_data, condition_id, check_condition_exists,
                 check_condition_over_project)

--- a/condition-api/src/condition_api/resources/condition.py
+++ b/condition-api/src/condition_api/resources/condition.py
@@ -89,8 +89,8 @@ class ConditionDetailsPatchResource(Resource):
         try:
             conditions_data = ConditionSchema().load(API.payload)
             query_params = request.args
-            check_condition_exists = query_params.get('check_condition_exists', '', type=str)
-            check_condition_over_project = query_params.get('check_condition_over_project', '', type=str)
+            check_condition_exists = query_params.get('check_condition_exists', 'false', type=str).lower() == 'true'
+            check_condition_over_project = query_params.get('check_condition_over_project', 'false', type=str).lower() == 'true'
             updated_condition = ConditionService.update_condition(
                 conditions_data, condition_id, check_condition_exists,
                 check_condition_over_project)

--- a/condition-api/src/condition_api/services/condition_service.py
+++ b/condition-api/src/condition_api/services/condition_service.py
@@ -732,6 +732,7 @@ class ConditionService:
             "is_standard_condition": condition_data.is_standard_condition,
             "topic_tags": condition_data.topic_tags,
             "subtopic_tags": condition_data.subtopic_tags,
+            "condition_type": condition_data.condition_type,
             "year_issued": year_issued,
             "condition_attributes": [],
             "subconditions": []
@@ -761,7 +762,8 @@ class ConditionService:
             Condition.is_approved,
             Condition.is_standard_condition,
             Condition.topic_tags,
-            Condition.subtopic_tags
+            Condition.subtopic_tags,
+            Condition.condition_type
         ).filter(Condition.id == condition_id).first()
 
     @staticmethod
@@ -1352,6 +1354,7 @@ class ConditionService:
                 conditions.is_standard_condition,
                 conditions.requires_management_plan,
                 conditions.subtopic_tags,
+                conditions.condition_type,
                 subconditions.id.label("subcondition_id"),
                 subconditions.subcondition_identifier,
                 subconditions.subcondition_text,
@@ -1384,6 +1387,7 @@ class ConditionService:
             "is_standard_condition": first.is_standard_condition,
             "requires_management_plan": first.requires_management_plan,
             "subtopic_tags": first.subtopic_tags,
+            "condition_type": first.condition_type,
             "year_issued": first.year_issued,
             "condition_attributes": [],
             "subconditions": [],

--- a/condition-api/src/condition_api/services/extraction_request_service.py
+++ b/condition-api/src/condition_api/services/extraction_request_service.py
@@ -174,6 +174,23 @@ class ExtractionRequestService:
         return req
 
     @staticmethod
+    def _deactivate_project_if_no_active_docs(project_id, exclude_document_id):
+        """Deactivate the project when no other active documents remain."""
+        other_active = (
+            db.session.query(Document)
+            .filter(
+                Document.project_id == project_id,
+                Document.document_id != exclude_document_id,
+                Document.is_active.is_(True),
+            )
+            .first()
+        )
+        if not other_active:
+            project = db.session.query(Project).filter_by(project_id=project_id).first()
+            if project:
+                project.is_active = False
+
+    @staticmethod
     def reject_request(request_id: int):
         """Reject an extraction request and purge its raw extracted JSON."""
         req = db.session.query(ExtractionRequest).filter_by(id=request_id).first()
@@ -188,21 +205,10 @@ class ExtractionRequestService:
                 document = db.session.query(Document).filter_by(document_id=req.document_id).first()
                 if document:
                     document.is_active = False
-
                     if document.project_id:
-                        other_active = (
-                            db.session.query(Document)
-                            .filter(
-                                Document.project_id == document.project_id,
-                                Document.document_id != req.document_id,
-                                Document.is_active == True,  # noqa: E712
-                            )
-                            .first()
+                        ExtractionRequestService._deactivate_project_if_no_active_docs(
+                            document.project_id, req.document_id
                         )
-                        if not other_active:
-                            project = db.session.query(Project).filter_by(project_id=document.project_id).first()
-                            if project:
-                                project.is_active = False
 
             db.session.commit()
         except SQLAlchemyError as exc:

--- a/condition-web/src/components/ConditionDetails/ConditionHeader.tsx
+++ b/condition-web/src/components/ConditionDetails/ConditionHeader.tsx
@@ -3,7 +3,7 @@ import { Box, Button, Grid, Stack, Typography, TextField } from "@mui/material";
 import EditIcon from '@mui/icons-material/Edit';
 import SaveAltIcon from '@mui/icons-material/SaveAlt';
 import DocumentStatusChip from "../Projects/DocumentStatusChip";
-import { ConditionModel } from "@/models/Condition";
+import { ConditionModel, ConditionType } from "@/models/Condition";
 import { BCDesignTokens } from "epic.theme";
 import { StyledLabel } from "../Shared/Table/common";
 import { useUpdateConditionDetails } from "@/hooks/api/useConditions";
@@ -34,8 +34,6 @@ const ConditionHeader = ({
     const [editConditionMode, setEditConditionMode] = useState(false);
     const [conditionNumber, setConditionNumber] = useState(condition?.condition_number || "");
     const [conditionName, setConditionName] = useState(condition?.condition_name || "");
-    const [checkConditionExists, setCheckConditionExists] = useState(false);
-    const [checkConditionExistsForProject, setCheckConditionExistsForProject] = useState(false);
     const [conditionConflictError, setConditionConflictError] = useState(false);
     const [approvalError, setApprovalError] = useState(false);
     const [approvalErrorMessage, setApprovalErrorMessage] = useState("");
@@ -54,9 +52,11 @@ const ConditionHeader = ({
         });
     };
 
+    const isAmendCondition = condition.condition_type === ConditionType.AMEND;
+
     const { data: conditionDetails, mutateAsync: updateConditionDetails } = useUpdateConditionDetails(
-        checkConditionExists,
-        checkConditionExistsForProject,
+        true,
+        isAmendCondition,
         conditionId,
         {
           onSuccess: onCreateSuccess,
@@ -79,23 +79,23 @@ const ConditionHeader = ({
     };
 
     const handleSave = async () => {
-        setCheckConditionExists(true);
-
         if (!conditionNumber) {
           notify.error("Condition number is required.");
-          setCheckConditionExists(false);
           return;
         }
 
         if (!conditionName?.trim()) {
           notify.error("Condition name is required.");
-          setCheckConditionExists(false);
           return;
         }
 
         const data: PartialUpdateTopicTagsModel = {};
 
         if (Number(conditionNumber) !== Number(condition.condition_number)) {
+            if (isAmendCondition) {
+              setConditionConflictError(true);
+              return;
+            }
             data.condition_number = conditionNumber ? Number(conditionNumber) : condition.condition_number;
         }
 
@@ -107,8 +107,6 @@ const ConditionHeader = ({
           try {
             await updateConditionDetails(data);
             setEditConditionMode(false);
-            setCheckConditionExists(false);
-            setCheckConditionExistsForProject(false);
             setConditionConflictError(false);
             setApprovalErrorMessage('');
             setApprovalError(false);
@@ -183,10 +181,13 @@ const ConditionHeader = ({
                     marginBottom: "-22px"
                   }}
                 >
-                  <TextField 
-                    variant="outlined" 
+                  <TextField
+                    variant="outlined"
                     value={conditionNumber}
-                    onChange={(e) => setConditionNumber(e.target.value)}
+                    onChange={(e) => {
+                      setConditionNumber(e.target.value);
+                      setConditionConflictError(false);
+                    }}
                     sx={{
                       width: calculateWidth(String(conditionNumber)),
                       "& .MuiOutlinedInput-root": {
@@ -215,10 +216,7 @@ const ConditionHeader = ({
                   <Button
                     variant="contained"
                     size="small"
-                    onClick={() => {
-                      setCheckConditionExistsForProject(true);
-                      handleSave();
-                    }}
+                    onClick={handleSave}
                     sx={{
                       alignSelf: "stretch",
                       borderRadius: "0 4px 4px 0",
@@ -302,10 +300,7 @@ const ConditionHeader = ({
                       <Button
                         variant="contained"
                         size="small"
-                        onClick={() => {
-                          setCheckConditionExistsForProject(true);
-                          handleSave();
-                        }}
+                        onClick={handleSave}
                         sx={{
                           alignSelf: "stretch",
                           borderRadius: "0 4px 4px 0",
@@ -371,7 +366,9 @@ const ConditionHeader = ({
                     fontSize: "14px",
                   }}
                 >
-                  This condition number already exists. Please enter a new one.
+                  {isAmendCondition
+                    ? "The condition number cannot be changed because this condition is amending an existing condition."
+                    : "This condition number already exists. Please enter a new one."}
                 </Box>
               )}
               {((!conditionName && canManage) || approvalError) && (


### PR DESCRIPTION
**Summary**

- Add New Condition: users were getting a system error when editing the condition number — the project-wide conflict check was incorrectly applied to all conditions
- Amend from Existing: condition number could be freely changed with no validation due to a React state timing bug and Python boolean parsing bug ("false" string evaluated as truthy)
- condition_type was missing from the condition detail API response, so the frontend couldn't distinguish ADD vs AMEND conditions

**Changes**

- Fixed check_condition_over_project boolean parsing in the /edit endpoint (string "false" was truthy in Python)
- Added condition_type to condition detail API responses (was never returned)
- Replaced stale React state flags with isAmendCondition derived directly from condition.condition_type — eliminates async state timing race
- AMEND conditions now show an inline error when attempting to change the number; ADD conditions skip the project-wide check entirely