### PR TITLE
CR-194:Document appearing in duplication after switch to manual entry + project not appearing

### DIFF
--- a/condition-api/src/condition_api/resources/document.py
+++ b/condition-api/src/condition_api/resources/document.py
@@ -176,6 +176,29 @@ class DocumentTypeResource(Resource):
             return {"message": str(err)}, HTTPStatus.BAD_REQUEST
 
 
+@cors_preflight("PATCH, OPTIONS")
+@API.route("/<string:document_id>/details", methods=["PATCH", "OPTIONS"])
+class DocumentDetailsResource(Resource):
+    """Resource for updating the full details of an existing document."""
+
+    @staticmethod
+    @ApiHelper.swagger_decorators(API, endpoint_description="Update document details")
+    @API.response(code=HTTPStatus.OK, model=document_model, description="Update document details")
+    @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
+    @auth.has_one_of_roles([EpicConditionRole.MANAGE_CONDITIONS.value])
+    @cross_origin(origins=allowedorigins())
+    def patch(document_id):
+        """Update an existing document's details (used for manual entry transfer)."""
+        try:
+            documents_data = DocumentSchema().load(API.payload, partial=True)
+            updated_document = DocumentService.update_document_details(document_id, documents_data)
+            return DocumentSchema().dump(updated_document), HTTPStatus.OK
+        except ValueError as err:
+            return {"message": str(err)}, HTTPStatus.BAD_REQUEST
+        except ValidationError as err:
+            return {"message": str(err)}, HTTPStatus.BAD_REQUEST
+
+
 @cors_preflight("GET, PATCH, OPTIONS")
 @API.route("/<string:document_id>", methods=["GET", "PATCH", "OPTIONS"])
 class DocumentResource(Resource):

--- a/condition-api/src/condition_api/services/document_service.py
+++ b/condition-api/src/condition_api/services/document_service.py
@@ -231,8 +231,7 @@ class DocumentService:
 
     @staticmethod
     def update_document_details(document_id, document):
-        """Update an existing document's details in place.
-        """
+        """Update an existing document's details in place."""
         existing_document = db.session.query(Document).filter_by(document_id=document_id).first()
         if not existing_document:
             raise ValueError("Document not found")

--- a/condition-api/src/condition_api/services/document_service.py
+++ b/condition-api/src/condition_api/services/document_service.py
@@ -230,6 +230,28 @@ class DocumentService:
         return new_document
 
     @staticmethod
+    def update_document_details(document_id, document):
+        """Update an existing document's details in place.
+        """
+        existing_document = db.session.query(Document).filter_by(document_id=document_id).first()
+        if not existing_document:
+            raise ValueError("Document not found")
+
+        date_issued = document.get("date_issued")
+        if not date_issued:
+            date_issued = date.today()
+
+        existing_document.document_label = document.get("document_label")
+        existing_document.document_link = document.get("document_link")
+        existing_document.document_type_id = document.get("document_type_id")
+        existing_document.date_issued = date_issued
+        existing_document.is_latest_amendment_added = document.get("is_latest_amendment_added")
+        existing_document.is_active = document.get("is_active")
+
+        db.session.commit()
+        return existing_document
+
+    @staticmethod
     def get_all_documents_by_project_id(project_id, document_id=None, document_type=None):
         """Fetch all documents and its amendments for the given project_id."""
         documents_query = db.session.query(

--- a/condition-api/src/condition_api/services/extraction_request_service.py
+++ b/condition-api/src/condition_api/services/extraction_request_service.py
@@ -174,6 +174,25 @@ class ExtractionRequestService:
         return req
 
     @staticmethod
+    def _maybe_deactivate_project(document, exclude_document_id):
+        """Deactivate the project if no other active documents remain."""
+        if not document.project_id:
+            return
+        other_active = (
+            db.session.query(Document)
+            .filter(
+                Document.project_id == document.project_id,
+                Document.document_id != exclude_document_id,
+                Document.is_active.is_(True),
+            )
+            .first()
+        )
+        if not other_active:
+            project = db.session.query(Project).filter_by(project_id=document.project_id).first()
+            if project:
+                project.is_active = False
+
+    @staticmethod
     def reject_request(request_id: int):
         """Reject an extraction request and purge its raw extracted JSON."""
         req = db.session.query(ExtractionRequest).filter_by(id=request_id).first()
@@ -188,21 +207,7 @@ class ExtractionRequestService:
                 document = db.session.query(Document).filter_by(document_id=req.document_id).first()
                 if document:
                     document.is_active = False
-
-                    if document.project_id:
-                        other_active = (
-                            db.session.query(Document)
-                            .filter(
-                                Document.project_id == document.project_id,
-                                Document.document_id != req.document_id,
-                                Document.is_active == True,  # noqa: E712
-                            )
-                            .first()
-                        )
-                        if not other_active:
-                            project = db.session.query(Project).filter_by(project_id=document.project_id).first()
-                            if project:
-                                project.is_active = False
+                    ExtractionRequestService._maybe_deactivate_project(document, req.document_id)
 
             db.session.commit()
         except SQLAlchemyError as exc:

--- a/condition-web/src/components/Documents/DocumentEntryForm.tsx
+++ b/condition-web/src/components/Documents/DocumentEntryForm.tsx
@@ -20,7 +20,7 @@ import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { DocumentType, DocumentTypeModel } from "@/models/Document";
 import { ProjectModel } from "@/models/Project";
 import { DocumentTypes } from "@/utils/enums";
-import { useCreateDocument, useGetDocumentsByProject } from "@/hooks/api/useDocuments";
+import { useCreateDocument, useGetDocumentsByProject, useUpdateDocumentDetails } from "@/hooks/api/useDocuments";
 import { useCreateAmendment } from "@/hooks/api/useAmendments";
 import { useManualEntryExtractionRequest } from "@/hooks/api/useExtractionRequests";
 import { CreateAmendmentModel } from "@/models/Amendment";
@@ -41,6 +41,7 @@ type DocumentEntryFormProps = {
         projectId?: string;
         documentTypeId?: number;
         documentLabel?: string;
+        documentId?: string;
         dateIssued?: string;
         extractionRequestId?: number;
     };
@@ -166,6 +167,14 @@ export const DocumentEntryForm = ({
         }
     );
 
+    const { mutateAsync: updateDocumentDetails } = useUpdateDocumentDetails(
+        transferData?.documentId,
+        {
+            onSuccess: () => notify.success("Document created successfully"),
+            onError: () => notify.error("Failed to create document"),
+        }
+    );
+
     const { mutateAsync: rejectExtractionRequest } = useManualEntryExtractionRequest();
 
     const { mutateAsync: createAmendment } = useCreateAmendment(
@@ -189,6 +198,9 @@ export const DocumentEntryForm = ({
             formState.selectedDocumentType === DocumentTypes.Amendment &&
             formState.selectedDocumentId;
 
+        // Manual entry replacing a failed extraction reuses the original document record.
+        const isManualEntryUpdate = !isAmendment && !!transferData?.documentId;
+
         updateFormState({
             isLatestAmendment: formState.selectedDocumentType === DocumentTypes.OtherOrder,
         });
@@ -206,12 +218,15 @@ export const DocumentEntryForm = ({
                 document_type_id: formState.selectedDocumentType,
                 date_issued: formattedDateIssued,
                 is_latest_amendment_added: formState.isLatestAmendment,
+                is_active: true,
             };
 
         try {
             const response = isAmendment
                 ? await createAmendment(payload as CreateAmendmentModel)
-                : await createDocument(payload as CreateDocumentModel);
+                : isManualEntryUpdate
+                    ? await updateDocumentDetails(payload as CreateDocumentModel)
+                    : await createDocument(payload as CreateDocumentModel);
 
             queryClient.invalidateQueries({ queryKey: ["projects"] });
 
@@ -222,7 +237,9 @@ export const DocumentEntryForm = ({
             if (response) {
                 const navigateTo = isAmendment
                     ? `/conditions/project/${formState.selectedProject?.project_id}/document/${response.amended_document_id}`
-                    : `/conditions/project/${response.project_id}/document/${response.document_id}`;
+                    : isManualEntryUpdate
+                        ? `/conditions/project/${formState.selectedProject?.project_id}/document/${transferData?.documentId}`
+                        : `/conditions/project/${response.project_id}/document/${response.document_id}`;
 
                 navigate({ to: navigateTo });
             }

--- a/condition-web/src/components/Documents/DocumentEntryPage.tsx
+++ b/condition-web/src/components/Documents/DocumentEntryPage.tsx
@@ -16,6 +16,7 @@ type DocumentEntryPageProps = {
         projectId?: string;
         documentTypeId?: number;
         documentLabel?: string;
+        documentId?: string;
         dateIssued?: string;
         extractionRequestId?: number;
     };
@@ -55,6 +56,7 @@ export const DocumentEntryPage = ({
                         projectId: manualEntrySearch.projectId,
                         documentTypeId: manualEntrySearch.documentTypeId,
                         documentLabel: manualEntrySearch.documentLabel,
+                        documentId: manualEntrySearch.documentId,
                         dateIssued: manualEntrySearch.dateIssued,
                         extractionRequestId: manualEntrySearch.extractionRequestId,
                     } : undefined}

--- a/condition-web/src/components/ExtractedDocuments/ExtractedDocumentsPage.tsx
+++ b/condition-web/src/components/ExtractedDocuments/ExtractedDocumentsPage.tsx
@@ -511,6 +511,7 @@ export default function ExtractedDocumentsPage() {
                                     projectId: req.project_id,
                                     documentTypeId: req.document_type_id,
                                     documentLabel: req.document_label,
+                                    documentId: req.document_id,
                                     extractionRequestId: req.id,
                                   },
                                 })

--- a/condition-web/src/hooks/api/useDocuments.tsx
+++ b/condition-web/src/hooks/api/useDocuments.tsx
@@ -153,6 +153,32 @@ export const useCreateDocument = (
   });
 };
 
+const updateDocumentDetails = (
+  documentId: string,
+  documentDetails: CreateDocumentModel
+) => {
+  return submitRequest({
+    url: `/documents/${documentId}/details`,
+    method: "patch",
+    data: documentDetails,
+  });
+};
+
+export const useUpdateDocumentDetails = (
+  documentId?: string,
+  options?: Options
+) => {
+  return useMutation({
+    mutationFn: (documentDetails: CreateDocumentModel) => {
+      if (!documentId) {
+        return Promise.reject(new Error("Document ID is required"));
+      }
+      return updateDocumentDetails(documentId, documentDetails);
+    },
+    ...options,
+  });
+};
+
 const fetchDocumentsByProject = (projectId?: string, documentId?: string, documentType?: string) => {
   if (!projectId) {
     return Promise.reject(new Error("Project ID is required"));

--- a/condition-web/src/models/Document.ts
+++ b/condition-web/src/models/Document.ts
@@ -65,6 +65,7 @@ export interface CreateDocumentModel {
   document_type_id?: number | null;
   date_issued?: string | null;
   is_latest_amendment_added?: boolean | null;
+  is_active?: boolean;
 }
 
 export enum DocumentType {

--- a/condition-web/src/routes/_authenticated/documents/extract/index.tsx
+++ b/condition-web/src/routes/_authenticated/documents/extract/index.tsx
@@ -2,7 +2,8 @@ import { useEffect } from "react";
 import { createFileRoute, useSearch } from "@tanstack/react-router";
 import { Grid } from "@mui/material";
 import { useGetDocumentType } from "@/hooks/api/useDocuments";
-import { useGetProjects } from "@/hooks/api/useProjects";
+import { useGetAllProjects, useGetProjects } from "@/hooks/api/useProjects";
+import { ProjectModel } from "@/models/Project";
 import { PageGrid } from "@/components/Shared/PageGrid";
 import { DocumentEntryPage } from "@/components/Documents/DocumentEntryPage";
 import { notify } from "@/components/Shared/Snackbar/snackbarStore";
@@ -22,6 +23,7 @@ export const Route = createFileRoute(
                 ? Number(search.documentTypeId)
                 : undefined,
         documentLabel: typeof search.documentLabel === "string" ? search.documentLabel : undefined,
+        documentId: typeof search.documentId === "string" ? search.documentId : undefined,
         dateIssued: typeof search.dateIssued === "string" ? search.dateIssued : undefined,
         extractionRequestId: typeof search.extractionRequestId === "number"
             ? search.extractionRequestId
@@ -41,6 +43,11 @@ export function DocumentExtractPage() {
         isError: isProjectsError,
     } = useGetProjects();
 
+    const {
+        data: allProjectsData,
+        isError: isAllProjectsError,
+    } = useGetAllProjects();
+
     const { data: documentTypeData } = useGetDocumentType();
     const { replaceBreadcrumb } = useBreadCrumb();
     const manualEntrySearch = useSearch({ from: Route.id });
@@ -50,8 +57,14 @@ export function DocumentExtractPage() {
     }, [replaceBreadcrumb]);
 
     useEffect(() => {
-        if (isProjectsError) notify.error("Failed to load projects");
-    }, [isProjectsError]);
+        if (isProjectsError || isAllProjectsError) notify.error("Failed to load projects");
+    }, [isProjectsError, isAllProjectsError]);
+
+    const projects: ProjectModel[] = (allProjectsData ?? []).map((project) => ({
+        project_id: project.project_id,
+        project_name: project.project_name,
+        documents: projectsData?.find((p: ProjectModel) => p.project_id === project.project_id)?.documents ?? [],
+    }));
 
     return (
         <>
@@ -59,7 +72,7 @@ export function DocumentExtractPage() {
             <PageGrid>
                 <Grid item xs={12}>
                     <DocumentEntryPage
-                        projects={projectsData ?? []}
+                        projects={projects}
                         documentType={documentTypeData ?? []}
                         manualEntrySearch={manualEntrySearch}
                     />


### PR DESCRIPTION
Summary

- Fix duplicate "Other Orders" documents: When manual entry replaced a failed extraction, a new Document row was created instead of reusing the existing one. Added update_document_details service method + PATCH /documents/<document_id>/details endpoint, a new useUpdateDocumentDetails hook, and updated DocumentEntryForm to update/reuse the original document instead of creating a duplicate.
- Fix Manual Entry project dropdown: It showed only active projects with documents, unlike the Extract tab which showed all projects. Now merges useGetProjects() and useGetAllProjects() so both tabs show the same project list.
