### PR TITLE
CR-192:Empty project shells appearing on Projects page

### DIFF
--- a/condition-api/src/condition_api/resources/condition.py
+++ b/condition-api/src/condition_api/resources/condition.py
@@ -90,7 +90,9 @@ class ConditionDetailsPatchResource(Resource):
             conditions_data = ConditionSchema().load(API.payload)
             query_params = request.args
             check_condition_exists = query_params.get('check_condition_exists', 'false', type=str).lower() == 'true'
-            check_condition_over_project = query_params.get('check_condition_over_project', 'false', type=str).lower() == 'true'
+            check_condition_over_project = (
+                query_params.get('check_condition_over_project', 'false', type=str).lower() == 'true'
+            )
             updated_condition = ConditionService.update_condition(
                 conditions_data, condition_id, check_condition_exists,
                 check_condition_over_project)

--- a/condition-api/src/condition_api/resources/condition.py
+++ b/condition-api/src/condition_api/resources/condition.py
@@ -89,8 +89,8 @@ class ConditionDetailsPatchResource(Resource):
         try:
             conditions_data = ConditionSchema().load(API.payload)
             query_params = request.args
-            check_condition_exists = query_params.get('check_condition_exists', '', type=str)
-            check_condition_over_project = query_params.get('check_condition_over_project', '', type=str)
+            check_condition_exists = query_params.get('check_condition_exists', 'false', type=str).lower() == 'true'
+            check_condition_over_project = query_params.get('check_condition_over_project', 'false', type=str).lower() == 'true'
             updated_condition = ConditionService.update_condition(
                 conditions_data, condition_id, check_condition_exists,
                 check_condition_over_project)

--- a/condition-api/src/condition_api/resources/document.py
+++ b/condition-api/src/condition_api/resources/document.py
@@ -176,6 +176,29 @@ class DocumentTypeResource(Resource):
             return {"message": str(err)}, HTTPStatus.BAD_REQUEST
 
 
+@cors_preflight("PATCH, OPTIONS")
+@API.route("/<string:document_id>/details", methods=["PATCH", "OPTIONS"])
+class DocumentDetailsResource(Resource):
+    """Resource for updating the full details of an existing document."""
+
+    @staticmethod
+    @ApiHelper.swagger_decorators(API, endpoint_description="Update document details")
+    @API.response(code=HTTPStatus.OK, model=document_model, description="Update document details")
+    @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
+    @auth.has_one_of_roles([EpicConditionRole.MANAGE_CONDITIONS.value])
+    @cross_origin(origins=allowedorigins())
+    def patch(document_id):
+        """Update an existing document's details (used for manual entry transfer)."""
+        try:
+            documents_data = DocumentSchema().load(API.payload, partial=True)
+            updated_document = DocumentService.update_document_details(document_id, documents_data)
+            return DocumentSchema().dump(updated_document), HTTPStatus.OK
+        except ValueError as err:
+            return {"message": str(err)}, HTTPStatus.BAD_REQUEST
+        except ValidationError as err:
+            return {"message": str(err)}, HTTPStatus.BAD_REQUEST
+
+
 @cors_preflight("GET, PATCH, OPTIONS")
 @API.route("/<string:document_id>", methods=["GET", "PATCH", "OPTIONS"])
 class DocumentResource(Resource):

--- a/condition-api/src/condition_api/schemas/extraction_request.py
+++ b/condition-api/src/condition_api/schemas/extraction_request.py
@@ -10,6 +10,8 @@ class ExtractionRequestSchema(Schema):
     document_id = fields.Str(allow_none=True)
     document_type_id = fields.Int(allow_none=True)
     document_label = fields.Str(allow_none=True)
+    date_issued = fields.Str(allow_none=True)
+    act = fields.Int(allow_none=True)
     original_file_name = fields.Str(allow_none=True)
     s3_url = fields.Str(required=True)
     file_size_bytes = fields.Int(allow_none=True)

--- a/condition-api/src/condition_api/schemas/project.py
+++ b/condition-api/src/condition_api/schemas/project.py
@@ -22,6 +22,7 @@ class ProjectSchema(BaseSchema):
 
     project_id = fields.Str(data_key="project_id")
     project_name = fields.Str(data_key="project_name")
+    project_type = fields.Str(data_key="project_type", allow_none=True)
     is_active = fields.Bool(data_key="is_active")
 
     # A project can have multiple documents

--- a/condition-api/src/condition_api/services/condition_service.py
+++ b/condition-api/src/condition_api/services/condition_service.py
@@ -732,6 +732,7 @@ class ConditionService:
             "is_standard_condition": condition_data.is_standard_condition,
             "topic_tags": condition_data.topic_tags,
             "subtopic_tags": condition_data.subtopic_tags,
+            "condition_type": condition_data.condition_type,
             "year_issued": year_issued,
             "condition_attributes": [],
             "subconditions": []
@@ -761,7 +762,8 @@ class ConditionService:
             Condition.is_approved,
             Condition.is_standard_condition,
             Condition.topic_tags,
-            Condition.subtopic_tags
+            Condition.subtopic_tags,
+            Condition.condition_type
         ).filter(Condition.id == condition_id).first()
 
     @staticmethod
@@ -1352,6 +1354,7 @@ class ConditionService:
                 conditions.is_standard_condition,
                 conditions.requires_management_plan,
                 conditions.subtopic_tags,
+                conditions.condition_type,
                 subconditions.id.label("subcondition_id"),
                 subconditions.subcondition_identifier,
                 subconditions.subcondition_text,
@@ -1384,6 +1387,7 @@ class ConditionService:
             "is_standard_condition": first.is_standard_condition,
             "requires_management_plan": first.requires_management_plan,
             "subtopic_tags": first.subtopic_tags,
+            "condition_type": first.condition_type,
             "year_issued": first.year_issued,
             "condition_attributes": [],
             "subconditions": [],

--- a/condition-api/src/condition_api/services/document_service.py
+++ b/condition-api/src/condition_api/services/document_service.py
@@ -231,8 +231,7 @@ class DocumentService:
 
     @staticmethod
     def update_document_details(document_id, document):
-        """Update an existing document's details in place.
-        """
+        """Update an existing document's details in place."""
         existing_document = db.session.query(Document).filter_by(document_id=document_id).first()
         if not existing_document:
             raise ValueError("Document not found")

--- a/condition-api/src/condition_api/services/document_service.py
+++ b/condition-api/src/condition_api/services/document_service.py
@@ -230,6 +230,28 @@ class DocumentService:
         return new_document
 
     @staticmethod
+    def update_document_details(document_id, document):
+        """Update an existing document's details in place.
+        """
+        existing_document = db.session.query(Document).filter_by(document_id=document_id).first()
+        if not existing_document:
+            raise ValueError("Document not found")
+
+        date_issued = document.get("date_issued")
+        if not date_issued:
+            date_issued = date.today()
+
+        existing_document.document_label = document.get("document_label")
+        existing_document.document_link = document.get("document_link")
+        existing_document.document_type_id = document.get("document_type_id")
+        existing_document.date_issued = date_issued
+        existing_document.is_latest_amendment_added = document.get("is_latest_amendment_added")
+        existing_document.is_active = document.get("is_active")
+
+        db.session.commit()
+        return existing_document
+
+    @staticmethod
     def get_all_documents_by_project_id(project_id, document_id=None, document_type=None):
         """Fetch all documents and its amendments for the given project_id."""
         documents_query = db.session.query(

--- a/condition-api/src/condition_api/services/document_service.py
+++ b/condition-api/src/condition_api/services/document_service.py
@@ -226,6 +226,11 @@ class DocumentService:
         db.session.add(new_document)
         db.session.flush()
 
+        # Activate the project so the document is visible in the condition repository.
+        project = db.session.query(Project).filter_by(project_id=project_id).first()
+        if project:
+            project.is_active = True
+
         db.session.commit()
         return new_document
 

--- a/condition-api/src/condition_api/services/extraction_request_service.py
+++ b/condition-api/src/condition_api/services/extraction_request_service.py
@@ -174,6 +174,23 @@ class ExtractionRequestService:
         return req
 
     @staticmethod
+    def _deactivate_project_if_no_active_docs(project_id, exclude_document_id):
+        """Deactivate the project when no other active documents remain."""
+        other_active = (
+            db.session.query(Document)
+            .filter(
+                Document.project_id == project_id,
+                Document.document_id != exclude_document_id,
+                Document.is_active.is_(True),
+            )
+            .first()
+        )
+        if not other_active:
+            project = db.session.query(Project).filter_by(project_id=project_id).first()
+            if project:
+                project.is_active = False
+
+    @staticmethod
     def reject_request(request_id: int):
         """Reject an extraction request and purge its raw extracted JSON."""
         req = db.session.query(ExtractionRequest).filter_by(id=request_id).first()
@@ -188,21 +205,10 @@ class ExtractionRequestService:
                 document = db.session.query(Document).filter_by(document_id=req.document_id).first()
                 if document:
                     document.is_active = False
-
                     if document.project_id:
-                        other_active = (
-                            db.session.query(Document)
-                            .filter(
-                                Document.project_id == document.project_id,
-                                Document.document_id != req.document_id,
-                                Document.is_active == True,  # noqa: E712
-                            )
-                            .first()
+                        ExtractionRequestService._deactivate_project_if_no_active_docs(
+                            document.project_id, req.document_id
                         )
-                        if not other_active:
-                            project = db.session.query(Project).filter_by(project_id=document.project_id).first()
-                            if project:
-                                project.is_active = False
 
             db.session.commit()
         except SQLAlchemyError as exc:

--- a/condition-api/src/condition_api/services/extraction_request_service.py
+++ b/condition-api/src/condition_api/services/extraction_request_service.py
@@ -169,6 +169,21 @@ class ExtractionRequestService:
                 if document:
                     document.is_active = False
 
+                    if document.project_id:
+                        other_active = (
+                            db.session.query(Document)
+                            .filter(
+                                Document.project_id == document.project_id,
+                                Document.document_id != req.document_id,
+                                Document.is_active == True,  # noqa: E712
+                            )
+                            .first()
+                        )
+                        if not other_active:
+                            project = db.session.query(Project).filter_by(project_id=document.project_id).first()
+                            if project:
+                                project.is_active = False
+
             db.session.commit()
         except SQLAlchemyError as exc:
             db.session.rollback()

--- a/condition-api/src/condition_api/services/extraction_request_service.py
+++ b/condition-api/src/condition_api/services/extraction_request_service.py
@@ -174,6 +174,25 @@ class ExtractionRequestService:
         return req
 
     @staticmethod
+    def _maybe_deactivate_project(document, exclude_document_id):
+        """Deactivate the project if no other active documents remain."""
+        if not document.project_id:
+            return
+        other_active = (
+            db.session.query(Document)
+            .filter(
+                Document.project_id == document.project_id,
+                Document.document_id != exclude_document_id,
+                Document.is_active.is_(True),
+            )
+            .first()
+        )
+        if not other_active:
+            project = db.session.query(Project).filter_by(project_id=document.project_id).first()
+            if project:
+                project.is_active = False
+
+    @staticmethod
     def reject_request(request_id: int):
         """Reject an extraction request and purge its raw extracted JSON."""
         req = db.session.query(ExtractionRequest).filter_by(id=request_id).first()
@@ -188,21 +207,7 @@ class ExtractionRequestService:
                 document = db.session.query(Document).filter_by(document_id=req.document_id).first()
                 if document:
                     document.is_active = False
-
-                    if document.project_id:
-                        other_active = (
-                            db.session.query(Document)
-                            .filter(
-                                Document.project_id == document.project_id,
-                                Document.document_id != req.document_id,
-                                Document.is_active == True,  # noqa: E712
-                            )
-                            .first()
-                        )
-                        if not other_active:
-                            project = db.session.query(Project).filter_by(project_id=document.project_id).first()
-                            if project:
-                                project.is_active = False
+                    ExtractionRequestService._maybe_deactivate_project(document, req.document_id)
 
             db.session.commit()
         except SQLAlchemyError as exc:

--- a/condition-api/src/condition_api/services/extraction_request_service.py
+++ b/condition-api/src/condition_api/services/extraction_request_service.py
@@ -52,12 +52,32 @@ class ExtractionRequestService:
         )
         db.session.add(request)
 
-        # Activate the document so it appears in the repository immediately
+        # Activate the document (create it first if it doesn't exist in the DB)
         document_id = data.get('document_id')
         if document_id:
             document = db.session.query(Document).filter_by(document_id=document_id).first()
-            if document:
-                document.is_active = True
+            if not document:
+                raw_date = data.get('date_issued')
+                parsed_date = None
+                if raw_date:
+                    try:
+                        parsed_date = datetime.strptime(raw_date[:10], '%Y-%m-%d').date()
+                    except ValueError:
+                        logger.warning("Could not parse date_issued '%s' for document_id=%s", raw_date, document_id)
+
+                document = Document(
+                    document_id=document_id,
+                    project_id=data['project_id'],
+                    document_type_id=data.get('document_type_id'),
+                    document_label=data.get('document_label'),
+                    date_issued=parsed_date,
+                    act=data.get('act'),
+                    is_active=False,
+                )
+                db.session.add(document)
+                logger.info("Created new document document_id=%s from extraction request", document_id)
+
+            document.is_active = True
 
         # Activate the project so it is visible in the repository
         project = db.session.query(Project).filter_by(project_id=data['project_id']).first()

--- a/condition-api/src/condition_api/services/extraction_request_service.py
+++ b/condition-api/src/condition_api/services/extraction_request_service.py
@@ -34,8 +34,8 @@ class ExtractionRequestService:
     def create(data: dict) -> ExtractionRequest:
         """Create a new extraction request with status pending.
 
-        Also activates the associated document and project so they are
-        immediately visible in the repository while extraction processes.
+        The document and project remain inactive until extraction is successfully
+        imported or the user completes manual entry.
         """
         current_staff_user = ExtractionRequestService._get_current_staff_user()
 
@@ -52,7 +52,8 @@ class ExtractionRequestService:
         )
         db.session.add(request)
 
-        # Activate the document (create it first if it doesn't exist in the DB)
+        # Ensure the document record exists in the DB so the extraction result can reference it.
+        # The document stays inactive until extraction is imported or manual entry is completed.
         document_id = data.get('document_id')
         if document_id:
             document = db.session.query(Document).filter_by(document_id=document_id).first()
@@ -76,13 +77,11 @@ class ExtractionRequestService:
                 )
                 db.session.add(document)
                 logger.info("Created new document document_id=%s from extraction request", document_id)
-
-            document.is_active = True
-
-        # Activate the project so it is visible in the repository
-        project = db.session.query(Project).filter_by(project_id=data['project_id']).first()
-        if project:
-            project.is_active = True
+            else:
+                # Always honour the document type the user explicitly selected, even
+                # when the document already exists in the DB with a different type.
+                if data.get('document_type_id'):
+                    document.document_type_id = data['document_type_id']
 
         db.session.commit()
         db.session.refresh(request)
@@ -165,6 +164,18 @@ class ExtractionRequestService:
             req.extracted_data = None
             req.error_message = None
 
+            # Activate the document and project now that the user has completed manual entry.
+            if req.document_id:
+                document = db.session.query(Document).filter_by(document_id=req.document_id).first()
+                if document:
+                    if req.document_type_id:
+                        document.document_type_id = req.document_type_id
+                    document.is_active = True
+
+            project = db.session.query(Project).filter_by(project_id=req.project_id).first()
+            if project:
+                project.is_active = True
+
             db.session.commit()
         except SQLAlchemyError as exc:
             db.session.rollback()
@@ -244,7 +255,14 @@ class ExtractionRequestService:
             if req.document_id:
                 document = db.session.query(Document).filter_by(document_id=req.document_id).first()
                 if document:
+                    if req.document_type_id:
+                        document.document_type_id = req.document_type_id
                     document.is_active = True
+
+            # Activate the project now that extraction is complete and imported.
+            project = db.session.query(Project).filter_by(project_id=req.project_id).first()
+            if project:
+                project.is_active = True
 
             db.session.commit()
         except (SQLAlchemyError, ValueError, TypeError):

--- a/condition-api/src/condition_api/services/project_service.py
+++ b/condition-api/src/condition_api/services/project_service.py
@@ -247,7 +247,10 @@ class ProjectService:
             .order_by(Project.project_name)
             .all()
         )
-        return [{"project_id": row.project_id, "project_name": row.project_name, "project_type": row.project_type} for row in projects]
+        return [
+            {"project_id": row.project_id, "project_name": row.project_name, "project_type": row.project_type}
+            for row in projects
+        ]
 
     @staticmethod
     def activate_project(project_id):

--- a/condition-api/src/condition_api/services/project_service.py
+++ b/condition-api/src/condition_api/services/project_service.py
@@ -243,11 +243,11 @@ class ProjectService:
     def get_all_projects_simple():
         """Fetch all projects (active and inactive) as a simple id/name list."""
         projects = (
-            db.session.query(Project.project_id, Project.project_name)
+            db.session.query(Project.project_id, Project.project_name, Project.project_type)
             .order_by(Project.project_name)
             .all()
         )
-        return [{"project_id": row.project_id, "project_name": row.project_name} for row in projects]
+        return [{"project_id": row.project_id, "project_name": row.project_name, "project_type": row.project_type} for row in projects]
 
     @staticmethod
     def activate_project(project_id):

--- a/condition-api/src/condition_api/templates/consolidated_conditions.html
+++ b/condition-api/src/condition_api/templates/consolidated_conditions.html
@@ -224,74 +224,69 @@
     }
 
     .subconditions-list {
-      display: table;
       width: 100%;
-      border-collapse: separate;
-      border-spacing: 0 6.4mm;
-      margin-top: -6.4mm;
       page-break-inside: auto;
     }
 
     .subcondition-item {
-      display: table-row;
+      display: block;
+      margin-bottom: 6.4mm;
+      page-break-inside: auto;
+    }
+
+    .subcondition-row {
+      display: block;
       page-break-inside: avoid;
     }
 
     .subcondition-identifier {
-      display: table-cell;
-      width: 14mm;
+      display: inline;
+      margin-right: 2.1mm;
       font-size: 12pt;
       font-weight: bold;
       color: #101828;
       line-height: 1.5;
-      vertical-align: top;
       white-space: nowrap;
     }
 
-    .subcondition-body {
-      display: table-cell;
-      vertical-align: top;
-    }
-
     .subcondition-text {
+      display: inline;
       font-size: 12pt;
       color: #101828;
       line-height: 1.5;
     }
 
     .nested-subconditions {
-      display: table;
-      width: 100%;
-      border-collapse: separate;
-      border-spacing: 0 2.1mm;
+      display: block;
       margin-top: 2.1mm;
-      margin-bottom: -2.1mm;
       padding-left: 8.5mm;
       page-break-inside: auto;
     }
 
     .nested-subcondition-item {
-      display: table-row;
+      display: block;
       page-break-inside: avoid;
     }
 
+    .nested-subcondition-item + .nested-subcondition-item {
+      margin-top: 2.1mm;
+    }
+
     .nested-identifier {
-      display: table-cell;
-      width: 8mm;
+      display: inline;
+      margin-right: 2.1mm;
       font-size: 12pt;
       font-weight: bold;
       color: #101828;
       line-height: 1.5;
-      vertical-align: top;
       white-space: nowrap;
     }
 
     .nested-text {
-      display: table-cell;
+      display: inline;
       font-size: 12pt;
       color: #101828;
       line-height: 1.5;
-      vertical-align: top;
     }
 
     .condition-separator {
@@ -400,20 +395,14 @@
     <div class="subconditions-list">
       {% for sub in condition.subconditions | sort(attribute='sort_order') %}
       <div class="subcondition-item">
-        <span class="subcondition-identifier">{{ sub.subcondition_identifier }}</span>
-        <div class="subcondition-body">
-          <span class="subcondition-text">{{ sub.subcondition_text }}</span>
-          {% if sub.subconditions %}
-          <div class="nested-subconditions">
-            {% for nested in sub.subconditions | sort(attribute='sort_order') %}
-            <div class="nested-subcondition-item">
-              <span class="nested-identifier">{{ nested.subcondition_identifier }}</span>
-              <span class="nested-text">{{ nested.subcondition_text }}</span>
-            </div>
-            {% endfor %}
-          </div>
-          {% endif %}
+        <div class="subcondition-row">{% if sub.subcondition_identifier %}<span class="subcondition-identifier">{{ sub.subcondition_identifier }}</span>{% endif %}<span class="subcondition-text">{{ sub.subcondition_text }}</span></div>
+        {% if sub.subconditions %}
+        <div class="nested-subconditions">
+          {% for nested in sub.subconditions | sort(attribute='sort_order') %}
+          <div class="nested-subcondition-item">{% if nested.subcondition_identifier %}<span class="nested-identifier">{{ nested.subcondition_identifier }}</span>{% endif %}<span class="nested-text">{{ nested.subcondition_text }}</span></div>
+          {% endfor %}
         </div>
+        {% endif %}
       </div>
       {% endfor %}
     </div>

--- a/condition-web/src/components/ConditionDetails/ConditionHeader.tsx
+++ b/condition-web/src/components/ConditionDetails/ConditionHeader.tsx
@@ -3,7 +3,7 @@ import { Box, Button, Grid, Stack, Typography, TextField } from "@mui/material";
 import EditIcon from '@mui/icons-material/Edit';
 import SaveAltIcon from '@mui/icons-material/SaveAlt';
 import DocumentStatusChip from "../Projects/DocumentStatusChip";
-import { ConditionModel } from "@/models/Condition";
+import { ConditionModel, ConditionType } from "@/models/Condition";
 import { BCDesignTokens } from "epic.theme";
 import { StyledLabel } from "../Shared/Table/common";
 import { useUpdateConditionDetails } from "@/hooks/api/useConditions";
@@ -34,8 +34,6 @@ const ConditionHeader = ({
     const [editConditionMode, setEditConditionMode] = useState(false);
     const [conditionNumber, setConditionNumber] = useState(condition?.condition_number || "");
     const [conditionName, setConditionName] = useState(condition?.condition_name || "");
-    const [checkConditionExists, setCheckConditionExists] = useState(false);
-    const [checkConditionExistsForProject, setCheckConditionExistsForProject] = useState(false);
     const [conditionConflictError, setConditionConflictError] = useState(false);
     const [approvalError, setApprovalError] = useState(false);
     const [approvalErrorMessage, setApprovalErrorMessage] = useState("");
@@ -54,9 +52,11 @@ const ConditionHeader = ({
         });
     };
 
+    const isAmendCondition = condition.condition_type === ConditionType.AMEND;
+
     const { data: conditionDetails, mutateAsync: updateConditionDetails } = useUpdateConditionDetails(
-        checkConditionExists,
-        checkConditionExistsForProject,
+        true,
+        isAmendCondition,
         conditionId,
         {
           onSuccess: onCreateSuccess,
@@ -79,23 +79,23 @@ const ConditionHeader = ({
     };
 
     const handleSave = async () => {
-        setCheckConditionExists(true);
-
         if (!conditionNumber) {
           notify.error("Condition number is required.");
-          setCheckConditionExists(false);
           return;
         }
 
         if (!conditionName?.trim()) {
           notify.error("Condition name is required.");
-          setCheckConditionExists(false);
           return;
         }
 
         const data: PartialUpdateTopicTagsModel = {};
 
         if (Number(conditionNumber) !== Number(condition.condition_number)) {
+            if (isAmendCondition) {
+              setConditionConflictError(true);
+              return;
+            }
             data.condition_number = conditionNumber ? Number(conditionNumber) : condition.condition_number;
         }
 
@@ -107,8 +107,6 @@ const ConditionHeader = ({
           try {
             await updateConditionDetails(data);
             setEditConditionMode(false);
-            setCheckConditionExists(false);
-            setCheckConditionExistsForProject(false);
             setConditionConflictError(false);
             setApprovalErrorMessage('');
             setApprovalError(false);
@@ -183,10 +181,13 @@ const ConditionHeader = ({
                     marginBottom: "-22px"
                   }}
                 >
-                  <TextField 
-                    variant="outlined" 
+                  <TextField
+                    variant="outlined"
                     value={conditionNumber}
-                    onChange={(e) => setConditionNumber(e.target.value)}
+                    onChange={(e) => {
+                      setConditionNumber(e.target.value);
+                      setConditionConflictError(false);
+                    }}
                     sx={{
                       width: calculateWidth(String(conditionNumber)),
                       "& .MuiOutlinedInput-root": {
@@ -215,10 +216,7 @@ const ConditionHeader = ({
                   <Button
                     variant="contained"
                     size="small"
-                    onClick={() => {
-                      setCheckConditionExistsForProject(true);
-                      handleSave();
-                    }}
+                    onClick={handleSave}
                     sx={{
                       alignSelf: "stretch",
                       borderRadius: "0 4px 4px 0",
@@ -302,10 +300,7 @@ const ConditionHeader = ({
                       <Button
                         variant="contained"
                         size="small"
-                        onClick={() => {
-                          setCheckConditionExistsForProject(true);
-                          handleSave();
-                        }}
+                        onClick={handleSave}
                         sx={{
                           alignSelf: "stretch",
                           borderRadius: "0 4px 4px 0",
@@ -371,7 +366,9 @@ const ConditionHeader = ({
                     fontSize: "14px",
                   }}
                 >
-                  This condition number already exists. Please enter a new one.
+                  {isAmendCondition
+                    ? "The condition number cannot be changed because this condition is amending an existing condition."
+                    : "This condition number already exists. Please enter a new one."}
                 </Box>
               )}
               {((!conditionName && canManage) || approvalError) && (

--- a/condition-web/src/components/Documents/DocumentEntryForm.tsx
+++ b/condition-web/src/components/Documents/DocumentEntryForm.tsx
@@ -20,7 +20,7 @@ import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { DocumentType, DocumentTypeModel } from "@/models/Document";
 import { ProjectModel } from "@/models/Project";
 import { DocumentTypes } from "@/utils/enums";
-import { useCreateDocument, useGetDocumentsByProject } from "@/hooks/api/useDocuments";
+import { useCreateDocument, useGetDocumentsByProject, useUpdateDocumentDetails } from "@/hooks/api/useDocuments";
 import { useCreateAmendment } from "@/hooks/api/useAmendments";
 import { useManualEntryExtractionRequest } from "@/hooks/api/useExtractionRequests";
 import { CreateAmendmentModel } from "@/models/Amendment";
@@ -41,6 +41,7 @@ type DocumentEntryFormProps = {
         projectId?: string;
         documentTypeId?: number;
         documentLabel?: string;
+        documentId?: string;
         dateIssued?: string;
         extractionRequestId?: number;
     };
@@ -166,6 +167,14 @@ export const DocumentEntryForm = ({
         }
     );
 
+    const { mutateAsync: updateDocumentDetails } = useUpdateDocumentDetails(
+        transferData?.documentId,
+        {
+            onSuccess: () => notify.success("Document created successfully"),
+            onError: () => notify.error("Failed to create document"),
+        }
+    );
+
     const { mutateAsync: rejectExtractionRequest } = useManualEntryExtractionRequest();
 
     const { mutateAsync: createAmendment } = useCreateAmendment(
@@ -189,6 +198,9 @@ export const DocumentEntryForm = ({
             formState.selectedDocumentType === DocumentTypes.Amendment &&
             formState.selectedDocumentId;
 
+        // Manual entry replacing a failed extraction reuses the original document record.
+        const isManualEntryUpdate = !isAmendment && !!transferData?.documentId;
+
         updateFormState({
             isLatestAmendment: formState.selectedDocumentType === DocumentTypes.OtherOrder,
         });
@@ -206,12 +218,15 @@ export const DocumentEntryForm = ({
                 document_type_id: formState.selectedDocumentType,
                 date_issued: formattedDateIssued,
                 is_latest_amendment_added: formState.isLatestAmendment,
+                is_active: true,
             };
 
         try {
             const response = isAmendment
                 ? await createAmendment(payload as CreateAmendmentModel)
-                : await createDocument(payload as CreateDocumentModel);
+                : isManualEntryUpdate
+                    ? await updateDocumentDetails(payload as CreateDocumentModel)
+                    : await createDocument(payload as CreateDocumentModel);
 
             queryClient.invalidateQueries({ queryKey: ["projects"] });
 
@@ -222,7 +237,9 @@ export const DocumentEntryForm = ({
             if (response) {
                 const navigateTo = isAmendment
                     ? `/conditions/project/${formState.selectedProject?.project_id}/document/${response.amended_document_id}`
-                    : `/conditions/project/${response.project_id}/document/${response.document_id}`;
+                    : isManualEntryUpdate
+                        ? `/conditions/project/${formState.selectedProject?.project_id}/document/${transferData?.documentId}`
+                        : `/conditions/project/${response.project_id}/document/${response.document_id}`;
 
                 navigate({ to: navigateTo });
             }

--- a/condition-web/src/components/Documents/DocumentEntryPage.tsx
+++ b/condition-web/src/components/Documents/DocumentEntryPage.tsx
@@ -16,6 +16,7 @@ type DocumentEntryPageProps = {
         projectId?: string;
         documentTypeId?: number;
         documentLabel?: string;
+        documentId?: string;
         dateIssued?: string;
         extractionRequestId?: number;
     };
@@ -55,6 +56,7 @@ export const DocumentEntryPage = ({
                         projectId: manualEntrySearch.projectId,
                         documentTypeId: manualEntrySearch.documentTypeId,
                         documentLabel: manualEntrySearch.documentLabel,
+                        documentId: manualEntrySearch.documentId,
                         dateIssued: manualEntrySearch.dateIssued,
                         extractionRequestId: manualEntrySearch.extractionRequestId,
                     } : undefined}

--- a/condition-web/src/components/Documents/DocumentExtractionForm.tsx
+++ b/condition-web/src/components/Documents/DocumentExtractionForm.tsx
@@ -229,7 +229,7 @@ export const DocumentExtractionForm = ({
                             <Link
                                 component="button"
                                 variant="caption"
-                                underline="always"
+                                underline="hover"
                                 onClick={() => setShowAllDocSearch(true)}
                                 sx={{
                                     display: "inline-flex",

--- a/condition-web/src/components/Documents/DocumentExtractionForm.tsx
+++ b/condition-web/src/components/Documents/DocumentExtractionForm.tsx
@@ -8,11 +8,16 @@ import {
     Box,
     Button,
     CircularProgress,
+    IconButton,
+    InputAdornment,
+    Link,
     Stack,
     TextField,
     Tooltip,
     Typography,
 } from "@mui/material";
+import SearchIcon from "@mui/icons-material/Search";
+import CloseIcon from "@mui/icons-material/Close";
 import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
 import UploadFileIcon from "@mui/icons-material/UploadFile";
@@ -20,10 +25,10 @@ import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import InsertDriveFileIcon from "@mui/icons-material/InsertDriveFile";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
 import { BCDesignTokens } from "epic.theme";
-import { DocumentLabelModel, DocumentTypeModel } from "@/models/Document";
+import { DocumentLabelModel, DocumentTypeModel, EaoSearchDocumentResult } from "@/models/Document";
 import { AvailableProjectModel } from "@/models/Project";
 import { useGetAllProjects } from "@/hooks/api/useProjects";
-import { useGetDocumentLabels } from "@/hooks/api/useDocuments";
+import { useGetDocumentLabels, useSearchEaoDocuments } from "@/hooks/api/useDocuments";
 import { S3_FOLDER, useUploadDocument } from "@/hooks/api/useObjectStorage";
 import { useCreateExtractionRequest } from "@/hooks/api/useExtractionRequests";
 import { notify } from "@/components/Shared/Snackbar/snackbarStore";
@@ -43,6 +48,7 @@ export const DocumentExtractionForm = ({
     const [selectedDocumentType, setSelectedDocumentType] = useState<DocumentTypeModel | null>(null);
     const [selectedDisplayName, setSelectedDisplayName] = useState<DocumentLabelModel | null>(null);
     const [showMore, setShowMore] = useState(false);
+    const [showAllDocSearch, setShowAllDocSearch] = useState(false);
 
     const { data: documentLabels = [], isPending: isLabelsLoading } = useGetDocumentLabels(
         selectedProject?.project_id,
@@ -51,6 +57,11 @@ export const DocumentExtractionForm = ({
     const [uploadedFile, setUploadedFile] = useState<File | null>(null);
     const [s3Key, setS3Key] = useState<string | null>(null);
     const [uploadSuccess, setUploadSuccess] = useState(false);
+
+    const { data: eaoResults = [], isFetching: isEaoLoading } = useSearchEaoDocuments(
+        selectedProject?.project_id,
+        showAllDocSearch
+    );
 
     const uploadDocument = useUploadDocument();
     const createExtractionRequest = useCreateExtractionRequest();
@@ -90,6 +101,8 @@ export const DocumentExtractionForm = ({
                             document_id: selectedDisplayName?.document_id ?? null,
                             document_type_id: selectedDocumentType?.id ?? null,
                             document_label: selectedDisplayName?.document_label ?? null,
+                            date_issued: selectedDisplayName?.date_issued ?? null,
+                            act: selectedDisplayName?.act ?? null,
                             original_file_name: uploadedFile.name,
                             s3_url: s3RelativeUrl,
                             file_size_bytes: uploadedFile.size,
@@ -148,6 +161,7 @@ export const DocumentExtractionForm = ({
                             setSelectedProject(v);
                             setSelectedDocumentType(null);
                             setSelectedDisplayName(null);
+                            setShowAllDocSearch(false);
                         }}
                         renderInput={(params) => (
                             <TextField
@@ -175,6 +189,7 @@ export const DocumentExtractionForm = ({
                             onChange={(_, v) => {
                                 setSelectedDocumentType(v);
                                 setSelectedDisplayName(null);
+                                setShowAllDocSearch(false);
                             }}
                             disabled={!selectedProject}
                             renderInput={(params) => (
@@ -199,6 +214,7 @@ export const DocumentExtractionForm = ({
                             getOptionLabel={(d) => d.document_label ?? ""}
                             onChange={(_, v) => setSelectedDisplayName(v)}
                             disabled={!selectedProject || !selectedDocumentType}
+                            sx={{ "& .MuiFormControl-root": { verticalAlign: "bottom", marginBottom: 0 } }}
                             renderInput={(params) => (
                                 <TextField
                                     {...params}
@@ -209,6 +225,85 @@ export const DocumentExtractionForm = ({
                                 />
                             )}
                         />
+                        {selectedProject && selectedDocumentType && !showAllDocSearch && (
+                            <Link
+                                component="button"
+                                variant="caption"
+                                underline="always"
+                                onClick={() => setShowAllDocSearch(true)}
+                                sx={{
+                                    display: "inline-flex",
+                                    alignItems: "center",
+                                    gap: 0.4,
+                                    cursor: "pointer",
+                                    color: "primary.main",
+                                }}
+                            >
+                                <SearchIcon sx={{ fontSize: 14 }} />
+                                Can't find it? Search all documents
+                            </Link>
+                        )}
+                        {showAllDocSearch && (
+                            <Box mt={1}>
+                                <Autocomplete<EaoSearchDocumentResult>
+                                    sx={{ "& .MuiFormControl-root": { marginBottom: 0 } }}
+                                    options={eaoResults}
+                                    loading={isEaoLoading}
+                                    getOptionLabel={(d) => d.displayName ?? ""}
+                                    isOptionEqualToValue={(a, b) => a._id === b._id}
+                                    renderOption={(props, option) => (
+                                        <li {...props} key={option._id}>
+                                            {option.displayName}
+                                        </li>
+                                    )}
+                                    onChange={(_, v) => {
+                                        if (v) {
+                                            setSelectedDisplayName({
+                                                document_id: v._id,
+                                                document_label: v.displayName,
+                                                date_issued: v.datePosted ? v.datePosted.split("T")[0] : null,
+                                                act: v.legislation ?? null,
+                                                project_type: selectedProject?.project_type ?? null,
+                                            });
+                                            setShowAllDocSearch(false);
+                                        }
+                                    }}
+                                    renderInput={(params) => (
+                                        <TextField
+                                            {...params}
+                                            placeholder="Search all documents…"
+                                            size="small"
+                                            fullWidth
+                                            autoFocus
+                                            InputProps={{
+                                                ...params.InputProps,
+                                                startAdornment: (
+                                                    <>
+                                                        <SearchIcon sx={{ color: "text.secondary", fontSize: 18, mr: 0.5 }} />
+                                                        {params.InputProps.startAdornment}
+                                                    </>
+                                                ),
+                                                endAdornment: (
+                                                    <>
+                                                        {params.InputProps.endAdornment}
+                                                        <InputAdornment position="end">
+                                                            <IconButton
+                                                                size="small"
+                                                                edge="end"
+                                                                onClick={() => setShowAllDocSearch(false)}
+                                                                sx={{ color: "text.secondary" }}
+                                                            >
+                                                                <CloseIcon fontSize="small" />
+                                                            </IconButton>
+                                                        </InputAdornment>
+                                                    </>
+                                                ),
+                                            }}
+                                        />
+                                    )}
+                                />
+                            </Box>
+                        )}
                     </Box>
                 </Box>
 

--- a/condition-web/src/components/Documents/DocumentExtractionForm.tsx
+++ b/condition-web/src/components/Documents/DocumentExtractionForm.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import { useDropzone } from "react-dropzone";
@@ -28,7 +28,7 @@ import { BCDesignTokens } from "epic.theme";
 import { DocumentLabelModel, DocumentTypeModel, EaoSearchDocumentResult } from "@/models/Document";
 import { AvailableProjectModel } from "@/models/Project";
 import { useGetAllProjects } from "@/hooks/api/useProjects";
-import { useGetDocumentLabels, useSearchEaoDocuments } from "@/hooks/api/useDocuments";
+import { useGetDocumentLabels, useGetDocumentsByProject, useSearchEaoDocuments } from "@/hooks/api/useDocuments";
 import { S3_FOLDER, useUploadDocument } from "@/hooks/api/useObjectStorage";
 import { useCreateExtractionRequest } from "@/hooks/api/useExtractionRequests";
 import { notify } from "@/components/Shared/Snackbar/snackbarStore";
@@ -61,6 +61,21 @@ export const DocumentExtractionForm = ({
     const { data: eaoResults = [], isFetching: isEaoLoading } = useSearchEaoDocuments(
         selectedProject?.project_id,
         showAllDocSearch
+    );
+
+    const { data: activeDocuments = [] } = useGetDocumentsByProject(
+        showAllDocSearch,
+        selectedProject?.project_id
+    );
+
+    const activeDocumentIds = useMemo(
+        () => new Set((activeDocuments as { document_id: string }[]).map((d) => d.document_id)),
+        [activeDocuments]
+    );
+
+    const filteredEaoResults = useMemo(
+        () => eaoResults.filter((d) => !activeDocumentIds.has(d._id)),
+        [eaoResults, activeDocumentIds]
     );
 
     const uploadDocument = useUploadDocument();
@@ -247,7 +262,7 @@ export const DocumentExtractionForm = ({
                             <Box mt={1}>
                                 <Autocomplete<EaoSearchDocumentResult>
                                     sx={{ "& .MuiFormControl-root": { marginBottom: 0 } }}
-                                    options={eaoResults}
+                                    options={filteredEaoResults}
                                     loading={isEaoLoading}
                                     getOptionLabel={(d) => d.displayName ?? ""}
                                     isOptionEqualToValue={(a, b) => a._id === b._id}

--- a/condition-web/src/components/ExtractedDocuments/ExtractedDocumentsPage.tsx
+++ b/condition-web/src/components/ExtractedDocuments/ExtractedDocumentsPage.tsx
@@ -511,6 +511,7 @@ export default function ExtractedDocumentsPage() {
                                     projectId: req.project_id,
                                     documentTypeId: req.document_type_id,
                                     documentLabel: req.document_label,
+                                    documentId: req.document_id,
                                     extractionRequestId: req.id,
                                   },
                                 })

--- a/condition-web/src/hooks/api/useDocuments.tsx
+++ b/condition-web/src/hooks/api/useDocuments.tsx
@@ -153,6 +153,32 @@ export const useCreateDocument = (
   });
 };
 
+const updateDocumentDetails = (
+  documentId: string,
+  documentDetails: CreateDocumentModel
+) => {
+  return submitRequest({
+    url: `/documents/${documentId}/details`,
+    method: "patch",
+    data: documentDetails,
+  });
+};
+
+export const useUpdateDocumentDetails = (
+  documentId?: string,
+  options?: Options
+) => {
+  return useMutation({
+    mutationFn: (documentDetails: CreateDocumentModel) => {
+      if (!documentId) {
+        return Promise.reject(new Error("Document ID is required"));
+      }
+      return updateDocumentDetails(documentId, documentDetails);
+    },
+    ...options,
+  });
+};
+
 const fetchDocumentsByProject = (projectId?: string, documentId?: string, documentType?: string) => {
   if (!projectId) {
     return Promise.reject(new Error("Project ID is required"));

--- a/condition-web/src/hooks/api/useDocuments.tsx
+++ b/condition-web/src/hooks/api/useDocuments.tsx
@@ -5,9 +5,10 @@ import {
   DocumentLabelModel,
   DocumentModel,
   DocumentDetailsModel,
+  EaoSearchResponse,
   ProjectDocumentAllAmendmentsModel
 } from "@/models/Document";
-import { submitRequest } from "@/utils/axiosUtils";
+import { submitRequest, requestAxios } from "@/utils/axiosUtils";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMutation } from "@tanstack/react-query";
 import { Options } from "./types";
@@ -60,6 +61,56 @@ export const useGetDocumentLabels = (projectId?: string, documentTypeId?: number
     queryFn: () => fetchDocumentLabels(projectId!, documentTypeId),
     enabled: Boolean(projectId && documentTypeId),
     ...defaultUseQueryOptions,
+  });
+};
+
+const EAO_SEARCH_BASE = 'https://projects.eao.gov.bc.ca/api/search';
+
+const EAO_PAGE_SIZE = 1000;
+
+const fetchEaoPage = (projectId: string, pageNum: number) => {
+  const params = new URLSearchParams({
+    dataset: 'Document',
+    pageNum: String(pageNum),
+    pageSize: String(EAO_PAGE_SIZE),
+    projectLegislation: 'default',
+    populate: 'false',
+    fuzzy: 'false',
+    'and[project]': projectId,
+    fields: '',
+  });
+  params.append('sortBy', '+displayName');
+  return requestAxios({ url: `${EAO_SEARCH_BASE}?${params.toString()}`, method: 'get' })
+    .then((data): EaoSearchResponse => {
+      const results: EaoSearchResponse[] = Array.isArray(data) ? data : [data];
+      return results[0];
+    });
+};
+
+const fetchEaoDocuments = async (projectId: string): Promise<EaoSearchDocumentResult[]> => {
+  const first = await fetchEaoPage(projectId, 0);
+  const total = first?.meta?.[0]?.searchResultsTotal ?? 0;
+  const allResults = [...(first?.searchResults ?? [])];
+
+  if (total > EAO_PAGE_SIZE) {
+    const extraPages = Math.ceil((total - EAO_PAGE_SIZE) / EAO_PAGE_SIZE);
+    const pages = await Promise.all(
+      Array.from({ length: extraPages }, (_, i) => fetchEaoPage(projectId, i + 1))
+    );
+    pages.forEach(p => allResults.push(...(p?.searchResults ?? [])));
+  }
+
+  return allResults;
+};
+
+export const useSearchEaoDocuments = (projectId?: string, enabled = false) => {
+  return useQuery({
+    queryKey: ['eao-documents', projectId],
+    queryFn: () => fetchEaoDocuments(projectId!),
+    enabled: Boolean(projectId) && enabled,
+    staleTime: 1000 * 60 * 5,
+    refetchOnWindowFocus: false,
+    retry: false,
   });
 };
 

--- a/condition-web/src/hooks/api/useDocuments.tsx
+++ b/condition-web/src/hooks/api/useDocuments.tsx
@@ -9,6 +9,7 @@ import {
   ProjectDocumentAllAmendmentsModel
 } from "@/models/Document";
 import { submitRequest, requestAxios } from "@/utils/axiosUtils";
+import { AppConfig } from "@/utils/config";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMutation } from "@tanstack/react-query";
 import { Options } from "./types";
@@ -64,7 +65,7 @@ export const useGetDocumentLabels = (projectId?: string, documentTypeId?: number
   });
 };
 
-const EAO_SEARCH_BASE = 'https://projects.eao.gov.bc.ca/api/search';
+const EAO_SEARCH_BASE = AppConfig.eaoSearchUrl;
 
 const EAO_PAGE_SIZE = 1000;
 

--- a/condition-web/src/hooks/api/useProjects.tsx
+++ b/condition-web/src/hooks/api/useProjects.tsx
@@ -34,6 +34,8 @@ export const useGetAllProjects = () => {
     queryKey: [QUERY_KEY.PROJECTS, 'all'],
     queryFn: fetchAllProjects,
     ...defaultUseQueryOptions,
+    staleTime: 0,
+    refetchOnMount: true,
   });
 };
 

--- a/condition-web/src/models/Document.ts
+++ b/condition-web/src/models/Document.ts
@@ -101,3 +101,16 @@ export interface AvailableDocumentModel {
   date_issued: string | null;
   document_type: string | null;
 }
+
+export interface EaoSearchDocumentResult {
+  _id: string;
+  displayName: string;
+  datePosted: string | null;
+  documentType: string | null;
+  legislation: number | null;
+}
+
+export interface EaoSearchResponse {
+  searchResults: EaoSearchDocumentResult[];
+  meta: Array<{ searchResultsTotal: number }>;
+}

--- a/condition-web/src/models/Document.ts
+++ b/condition-web/src/models/Document.ts
@@ -65,6 +65,7 @@ export interface CreateDocumentModel {
   document_type_id?: number | null;
   date_issued?: string | null;
   is_latest_amendment_added?: boolean | null;
+  is_active?: boolean;
 }
 
 export enum DocumentType {

--- a/condition-web/src/models/Project.ts
+++ b/condition-web/src/models/Project.ts
@@ -10,4 +10,5 @@ export interface ProjectModel {
 export interface AvailableProjectModel {
   project_id: string;
   project_name: string;
+  project_type?: string | null;
 }

--- a/condition-web/src/routes/_authenticated/documents/extract/index.tsx
+++ b/condition-web/src/routes/_authenticated/documents/extract/index.tsx
@@ -2,7 +2,8 @@ import { useEffect } from "react";
 import { createFileRoute, useSearch } from "@tanstack/react-router";
 import { Grid } from "@mui/material";
 import { useGetDocumentType } from "@/hooks/api/useDocuments";
-import { useGetProjects } from "@/hooks/api/useProjects";
+import { useGetAllProjects, useGetProjects } from "@/hooks/api/useProjects";
+import { ProjectModel } from "@/models/Project";
 import { PageGrid } from "@/components/Shared/PageGrid";
 import { DocumentEntryPage } from "@/components/Documents/DocumentEntryPage";
 import { notify } from "@/components/Shared/Snackbar/snackbarStore";
@@ -22,6 +23,7 @@ export const Route = createFileRoute(
                 ? Number(search.documentTypeId)
                 : undefined,
         documentLabel: typeof search.documentLabel === "string" ? search.documentLabel : undefined,
+        documentId: typeof search.documentId === "string" ? search.documentId : undefined,
         dateIssued: typeof search.dateIssued === "string" ? search.dateIssued : undefined,
         extractionRequestId: typeof search.extractionRequestId === "number"
             ? search.extractionRequestId
@@ -41,6 +43,11 @@ export function DocumentExtractPage() {
         isError: isProjectsError,
     } = useGetProjects();
 
+    const {
+        data: allProjectsData,
+        isError: isAllProjectsError,
+    } = useGetAllProjects();
+
     const { data: documentTypeData } = useGetDocumentType();
     const { replaceBreadcrumb } = useBreadCrumb();
     const manualEntrySearch = useSearch({ from: Route.id });
@@ -50,8 +57,14 @@ export function DocumentExtractPage() {
     }, [replaceBreadcrumb]);
 
     useEffect(() => {
-        if (isProjectsError) notify.error("Failed to load projects");
-    }, [isProjectsError]);
+        if (isProjectsError || isAllProjectsError) notify.error("Failed to load projects");
+    }, [isProjectsError, isAllProjectsError]);
+
+    const projects: ProjectModel[] = (allProjectsData ?? []).map((project) => ({
+        project_id: project.project_id,
+        project_name: project.project_name,
+        documents: projectsData?.find((p: ProjectModel) => p.project_id === project.project_id)?.documents ?? [],
+    }));
 
     return (
         <>
@@ -59,7 +72,7 @@ export function DocumentExtractPage() {
             <PageGrid>
                 <Grid item xs={12}>
                     <DocumentEntryPage
-                        projects={projectsData ?? []}
+                        projects={projects}
                         documentType={documentTypeData ?? []}
                         manualEntrySearch={manualEntrySearch}
                     />

--- a/condition-web/src/utils/config.ts
+++ b/condition-web/src/utils/config.ts
@@ -14,6 +14,7 @@ declare global {
       VITE_SUPPORT_EMAIL: string;
       VITE_OBJECT_STORAGE_URL: string;
       VITE_CONDITION_DOCUMENTS_FOLDER: string;
+      VITE_EAO_SEARCH_URL: string;
     VITE_ENABLE_NEW_SUBMIT_FLOW: string;
     };
   }
@@ -44,11 +45,14 @@ const CONDITION_DOCUMENTS_FOLDER =
   ).trim() || "condition_extraction_documents";
 const ENABLE_NEW_SUBMIT_FLOW =
   (window._env_?.VITE_ENABLE_NEW_SUBMIT_FLOW || import.meta.env.VITE_ENABLE_NEW_SUBMIT_FLOW || "false").toLowerCase() === "true";
+const EAO_SEARCH_URL =
+  window._env_?.VITE_EAO_SEARCH_URL || import.meta.env.VITE_EAO_SEARCH_URL || "https://projects.eao.gov.bc.ca/api/search";
 
 export const AppConfig = {
   apiUrl: `${API_URL}`,
   documentUrl: OBJECT_STORAGE_URL,
   conditionDocumentsFolder: CONDITION_DOCUMENTS_FOLDER,
+  eaoSearchUrl: EAO_SEARCH_URL,
   environment: APP_ENVIRONMENT,
   version: APP_VERSION,
   appTitle: APP_TITLE,


### PR DESCRIPTION
Changes:
- Project shell and document no longer appear in the repository while extraction is pending — deferred until import or manual entry is complete
- Documents selected via "search all documents" now land in the correct package — document_type_id is updated from the user's selection at request creation, import, and manual entry
- Project is now activated when a document is created via standalone manual entry
- Already-imported documents are filtered out of the "search all documents" EAO results