### PR TITLE
CR-192:Empty project shells appearing on Projects page

### DIFF
--- a/condition-api/src/condition_api/services/document_service.py
+++ b/condition-api/src/condition_api/services/document_service.py
@@ -226,6 +226,11 @@ class DocumentService:
         db.session.add(new_document)
         db.session.flush()
 
+        # Activate the project so the document is visible in the condition repository.
+        project = db.session.query(Project).filter_by(project_id=project_id).first()
+        if project:
+            project.is_active = True
+
         db.session.commit()
         return new_document
 

--- a/condition-api/src/condition_api/services/extraction_request_service.py
+++ b/condition-api/src/condition_api/services/extraction_request_service.py
@@ -34,8 +34,8 @@ class ExtractionRequestService:
     def create(data: dict) -> ExtractionRequest:
         """Create a new extraction request with status pending.
 
-        Also activates the associated document and project so they are
-        immediately visible in the repository while extraction processes.
+        The document and project remain inactive until extraction is successfully
+        imported or the user completes manual entry.
         """
         current_staff_user = ExtractionRequestService._get_current_staff_user()
 
@@ -52,7 +52,8 @@ class ExtractionRequestService:
         )
         db.session.add(request)
 
-        # Activate the document (create it first if it doesn't exist in the DB)
+        # Ensure the document record exists in the DB so the extraction result can reference it.
+        # The document stays inactive until extraction is imported or manual entry is completed.
         document_id = data.get('document_id')
         if document_id:
             document = db.session.query(Document).filter_by(document_id=document_id).first()
@@ -76,13 +77,11 @@ class ExtractionRequestService:
                 )
                 db.session.add(document)
                 logger.info("Created new document document_id=%s from extraction request", document_id)
-
-            document.is_active = True
-
-        # Activate the project so it is visible in the repository
-        project = db.session.query(Project).filter_by(project_id=data['project_id']).first()
-        if project:
-            project.is_active = True
+            else:
+                # Always honour the document type the user explicitly selected, even
+                # when the document already exists in the DB with a different type.
+                if data.get('document_type_id'):
+                    document.document_type_id = data['document_type_id']
 
         db.session.commit()
         db.session.refresh(request)
@@ -165,6 +164,18 @@ class ExtractionRequestService:
             req.extracted_data = None
             req.error_message = None
 
+            # Activate the document and project now that the user has completed manual entry.
+            if req.document_id:
+                document = db.session.query(Document).filter_by(document_id=req.document_id).first()
+                if document:
+                    if req.document_type_id:
+                        document.document_type_id = req.document_type_id
+                    document.is_active = True
+
+            project = db.session.query(Project).filter_by(project_id=req.project_id).first()
+            if project:
+                project.is_active = True
+
             db.session.commit()
         except SQLAlchemyError as exc:
             db.session.rollback()
@@ -244,7 +255,14 @@ class ExtractionRequestService:
             if req.document_id:
                 document = db.session.query(Document).filter_by(document_id=req.document_id).first()
                 if document:
+                    if req.document_type_id:
+                        document.document_type_id = req.document_type_id
                     document.is_active = True
+
+            # Activate the project now that extraction is complete and imported.
+            project = db.session.query(Project).filter_by(project_id=req.project_id).first()
+            if project:
+                project.is_active = True
 
             db.session.commit()
         except (SQLAlchemyError, ValueError, TypeError):

--- a/condition-web/src/components/Documents/DocumentExtractionForm.tsx
+++ b/condition-web/src/components/Documents/DocumentExtractionForm.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import { useDropzone } from "react-dropzone";
@@ -28,7 +28,7 @@ import { BCDesignTokens } from "epic.theme";
 import { DocumentLabelModel, DocumentTypeModel, EaoSearchDocumentResult } from "@/models/Document";
 import { AvailableProjectModel } from "@/models/Project";
 import { useGetAllProjects } from "@/hooks/api/useProjects";
-import { useGetDocumentLabels, useSearchEaoDocuments } from "@/hooks/api/useDocuments";
+import { useGetDocumentLabels, useGetDocumentsByProject, useSearchEaoDocuments } from "@/hooks/api/useDocuments";
 import { S3_FOLDER, useUploadDocument } from "@/hooks/api/useObjectStorage";
 import { useCreateExtractionRequest } from "@/hooks/api/useExtractionRequests";
 import { notify } from "@/components/Shared/Snackbar/snackbarStore";
@@ -61,6 +61,21 @@ export const DocumentExtractionForm = ({
     const { data: eaoResults = [], isFetching: isEaoLoading } = useSearchEaoDocuments(
         selectedProject?.project_id,
         showAllDocSearch
+    );
+
+    const { data: activeDocuments = [] } = useGetDocumentsByProject(
+        showAllDocSearch,
+        selectedProject?.project_id
+    );
+
+    const activeDocumentIds = useMemo(
+        () => new Set((activeDocuments as { document_id: string }[]).map((d) => d.document_id)),
+        [activeDocuments]
+    );
+
+    const filteredEaoResults = useMemo(
+        () => eaoResults.filter((d) => !activeDocumentIds.has(d._id)),
+        [eaoResults, activeDocumentIds]
     );
 
     const uploadDocument = useUploadDocument();
@@ -247,7 +262,7 @@ export const DocumentExtractionForm = ({
                             <Box mt={1}>
                                 <Autocomplete<EaoSearchDocumentResult>
                                     sx={{ "& .MuiFormControl-root": { marginBottom: 0 } }}
-                                    options={eaoResults}
+                                    options={filteredEaoResults}
                                     loading={isEaoLoading}
                                     getOptionLabel={(d) => d.displayName ?? ""}
                                     isOptionEqualToValue={(a, b) => a._id === b._id}


### PR DESCRIPTION
Changes:
- Project shell and document no longer appear in the repository while extraction is pending — deferred until import or manual entry is complete
- Documents selected via "search all documents" now land in the correct package — document_type_id is updated from the user's selection at request creation, import, and manual entry
- Project is now activated when a document is created via standalone manual entry
- Already-imported documents are filtered out of the "search all documents" EAO results