### PR TITLE
CR-198:Condition Requirements sections adding parathenses, but not displaying on Consolidated Conditions PDF

### DIFF
--- a/condition-web/src/components/ConditionDetails/SubCondition.tsx
+++ b/condition-web/src/components/ConditionDetails/SubCondition.tsx
@@ -148,9 +148,7 @@ const SubconditionComponent: React.FC<{
               <Typography variant="body2">
                 {subcondition.subcondition_identifier && (
                   <span style={{ color: theme.palette.primary.dark, marginRight: '8px' }}>
-                    {subcondition.subcondition_identifier.endsWith(')')
-                      ? subcondition.subcondition_identifier
-                      : `${subcondition.subcondition_identifier})`}
+                    {subcondition.subcondition_identifier}
                   </span>
                 )}
                 {subcondition.subcondition_text}


### PR DESCRIPTION
**Summary**
- In the Edit Condition Requirements view, section identifiers were automatically appended with ) on display if the user didn't include one themselves
- Removed this auto-formatting logic so identifiers render exactly as entered — no parentheses are added unless the user explicitly types them