### PR TITLE
CR-99:Rule for 'Add Document' pop-up

### DIFF
--- a/condition-web/src/components/Documents/DocumentEntryForm.tsx
+++ b/condition-web/src/components/Documents/DocumentEntryForm.tsx
@@ -151,6 +151,20 @@ export const DocumentEntryForm = ({
         DocumentTypes.Certificate.toString()
     );
 
+    useEffect(() => {
+        if (formState.selectedDocumentType !== DocumentTypes.Amendment || isDocumentsLoading) return;
+        const docs = (documentData || []) as DocumentModel[];
+        if (docs.length === 1) {
+            updateFormState({
+                selectedDocumentId: docs[0].document_record_id,
+                selectedDocumentLabel: docs[0].document_label,
+            });
+        } else {
+            updateFormState({ selectedDocumentId: null, selectedDocumentLabel: null });
+        }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [documentData, isDocumentsLoading, formState.selectedDocumentType]);
+
     const getDocumentName = (type: DocumentTypes | null): string => {
         switch (type) {
             case DocumentTypes.Certificate: return "Certificate";
@@ -344,9 +358,10 @@ export const DocumentEntryForm = ({
                     disabled={!formState.selectedProject}
                 />
 
-                {/* Amended Document Selector */}
+                {/* Amended Document Selector — only shown when multiple documents exist */}
                 {formState.selectedDocumentType === DocumentTypes.Amendment &&
-                    !isDocumentsLoading && (
+                    !isDocumentsLoading &&
+                    ((documentData || []) as DocumentModel[]).length > 1 && (
                         <>
                             <Typography variant="body1">Document being amended</Typography>
                             <Autocomplete


### PR DESCRIPTION
**Summary**
When adding an amendment manually, the "Document being Amended" dropdown is now only shown when a project has more than one Certificate/Exemption Order document. If the project has exactly one, it is automatically selected behind the scenes and the field is not rendered — reducing unnecessary steps for the user.

**Changes**
DocumentEntryForm.tsx — Added a useEffect that fires after the amendable documents list loads. When exactly one document is returned, it auto-populates selectedDocumentId and selectedDocumentLabel in form state. The "Document being Amended" dropdown is conditionally rendered only when documentData contains more than one entry.