### PR TITLE
CR-200:Changes to "Approved" language

### DIFF
--- a/condition-api/src/condition_api/templates/consolidated_conditions.html
+++ b/condition-api/src/condition_api/templates/consolidated_conditions.html
@@ -318,9 +318,9 @@
       <div class="header-project-name">{{ project_name }}</div>
       <div class="header-badge-row">
         {% if all_approved %}
-        <span class="badge badge-approved">Approved</span>
+        <span class="badge badge-approved">Confirmed</span>
         {% else %}
-        <span class="badge badge-awaiting">Awaiting Approval</span>
+        <span class="badge badge-awaiting">Awaiting Confirmation</span>
         {% endif %}
       </div>
     </div>
@@ -349,7 +349,7 @@
 
   <div class="info-box">
     <p>This Consolidated Conditions document contains the most recent condition information as entered in the Condition Repository. This is not an official or enforceable document and should be used supplementary to official documents.</p>
-    <p><strong>Note:</strong> Conditions with the status &#8216;Awaiting Approval&#8217; have not been approved by a staff member.</p>
+    <p><strong>Note:</strong> Conditions with the status &#8216;Awaiting Confirmation&#8217; have not been confirmed by a staff member.</p>
   </div>
 
   {% for condition in conditions %}
@@ -372,9 +372,9 @@
         </div>
         <div>
           {% if condition.is_approved %}
-          <span class="badge badge-approved">Approved</span>
+          <span class="badge badge-approved">Confirmed</span>
           {% else %}
-          <span class="badge badge-awaiting">Awaiting Approval</span>
+          <span class="badge badge-awaiting">Awaiting Confirmation</span>
           {% endif %}
         </div>
       </div>

--- a/condition-web/cypress/components/_routes/conditions/ConditionsDetails.cy.tsx
+++ b/condition-web/cypress/components/_routes/conditions/ConditionsDetails.cy.tsx
@@ -170,7 +170,7 @@ describe("conditions details page", () => {
     });
 
     // Assert that the condition attribute is approved
-    cy.contains("Approved").should("exist");
+    cy.contains("Confirmed").should("exist");
     cy.contains("Un-approve Management Plan Attributes").should("exist");
   });
 });

--- a/condition-web/src/components/Conditions/ConditionFilters.tsx
+++ b/condition-web/src/components/Conditions/ConditionFilters.tsx
@@ -42,8 +42,8 @@ export const ConditionFilters = ({
   amendments = [],
   years = [],
   statusOptions = [
-    { value: "true", label: "Approved" },
-    { value: "false", label: "Awaiting Approval" },
+    { value: "true", label: "Confirmed" },
+    { value: "false", label: "Awaiting Confirmation" },
   ],
   showSourceDocFilter = false,
   onFiltersChange,

--- a/condition-web/src/components/Projects/DocumentStatusChip.tsx
+++ b/condition-web/src/components/Projects/DocumentStatusChip.tsx
@@ -13,7 +13,7 @@ const statusStyles: Record<DocumentStatus, StyleProps> = {
       border: `2px solid ${BCDesignTokens.supportBorderColorSuccess}`,
       background: BCDesignTokens.supportSurfaceColorSuccess,
     },
-    label: "Approved",
+    label: "Confirmed",
   },
   false: {
     sx: {
@@ -21,7 +21,7 @@ const statusStyles: Record<DocumentStatus, StyleProps> = {
       border: `2px solid ${BCDesignTokens.themeGold100}`,
       background: BCDesignTokens.themeGold20,
     },
-    label: "Awaiting Approval",
+    label: "Awaiting Confirmation",
   },
   nodata: {
     sx: {

--- a/condition-web/src/models/Condition.ts
+++ b/condition-web/src/models/Condition.ts
@@ -90,10 +90,10 @@ export const CONDITION_STATUS: Record<
 > = {
   true: {
     value: "true",
-    label: "Approved",
+    label: "Confirmed",
   },
   false: {
     value: "false",
-    label: "Awaiting Approval",
+    label: "Awaiting Confirmation",
   }
 };

--- a/condition-web/src/models/Document.ts
+++ b/condition-web/src/models/Document.ts
@@ -25,7 +25,7 @@ export const DOCUMENT_STATUS: Record<
 > = {
   true: {
     value: "true",
-    label: "Approved",
+    label: "Confirmed",
   },
   false: {
     value: "false",


### PR DESCRIPTION
**Summary**
- Replace all instances of 'Approved' with 'Confirmed' across the system and consolidated PDF download
- Replace all instances of 'Awaiting Approval' with 'Awaiting Confirmation' across the system and consolidated PDF download
- 'Data Entry Required' label is unchanged
- No database values or API payloads were modified — this is a display-only change