### PR TITLE
CR-202:Consolidated Conditions PDF download restrictions

### DIFF
--- a/condition-api/src/condition_api/templates/consolidated_conditions.html
+++ b/condition-api/src/condition_api/templates/consolidated_conditions.html
@@ -427,13 +427,6 @@
         <div>
           <span class="metadata-label">Year Condition Issued:</span><span class="metadata-value">{{ condition.year_issued if condition.year_issued else '' }}</span>
         </div>
-        <div>
-          {% if condition.is_approved %}
-          <span class="badge badge-approved">Confirmed</span>
-          {% else %}
-          <span class="badge badge-awaiting">Awaiting Confirmation</span>
-          {% endif %}
-        </div>
       </div>
       <table class="metadata-row2">
         <tr>

--- a/condition-web/src/components/Conditions/ConditionTableRow.tsx
+++ b/condition-web/src/components/Conditions/ConditionTableRow.tsx
@@ -152,7 +152,7 @@ export default function ConditionTableRow({
           {condition.is_standard_condition ?? "--"}
         </TableCell>
         <TableCell
-          align="left"
+          align="right"
           sx={{
             borderBottom: border,
             pt: BCDesignTokens.layoutPaddingXsmall,

--- a/condition-web/src/components/Conditions/ConditionsTable.tsx
+++ b/condition-web/src/components/Conditions/ConditionsTable.tsx
@@ -165,7 +165,7 @@ export default function ConditionTable({
                             </TableSortLabel>
                         </StyledTableHeadCell>
 
-                        <StyledTableHeadCell align="left">
+                        <StyledTableHeadCell align="right">
                             <TableSortLabel
                                 active={orderBy === "is_approved"}
                                 direction={orderBy === "is_approved" ? order : "asc"}

--- a/condition-web/src/components/ConsolidatedConditions/index.tsx
+++ b/condition-web/src/components/ConsolidatedConditions/index.tsx
@@ -165,17 +165,24 @@ export const ConsolidatedConditions = ({
                 </Grid>
               )}
               <Grid item sx={{ pr: BCDesignTokens.layoutPaddingMedium }}>
-                <Button
-                  variant="contained"
-                  color="primary"
-                  size="small"
-                  startIcon={<FileDownloadOutlinedIcon />}
-                  onClick={handleExportPDF}
-                  disabled={isExporting || !filteredConditions?.length}
-                  sx={{ borderRadius: "4px", whiteSpace: "nowrap", width: "100%", minWidth: "170px", maxWidth: "200px", height: "42px" }}
-                >
-                  {isExporting ? "Exporting..." : "Export PDF"}
-                </Button>
+                <Stack direction="column" spacing={0.5} sx={{ mr: "6px", alignItems: "flex-end" }}>
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    size="small"
+                    startIcon={<FileDownloadOutlinedIcon />}
+                    onClick={handleExportPDF}
+                    disabled={isExporting || !filteredConditions?.length || !allApproved}
+                    sx={{ borderRadius: "4px", whiteSpace: "nowrap", width: "100%", height: "42px", minWidth: "170px", maxWidth: "200px" }}
+                  >
+                    {isExporting ? "Exporting..." : "Export PDF"}
+                  </Button>
+                  {!noConditions && !allApproved && (
+                    <Typography variant="caption" color="text.secondary" textAlign="right" sx={{ whiteSpace: "nowrap" }}>
+                      Conditions must be confirmed before exporting.
+                    </Typography>
+                  )}
+                </Stack>
               </Grid>
             </Grid>
             <Box height={"100%"} px={BCDesignTokens.layoutPaddingXsmall}>


### PR DESCRIPTION
### Summary

- Export PDF gate: The Export PDF button is now disabled until all conditions within the project have a status of Confirmed. An inline message — "Conditions must be confirmed before exporting." — appears below the disabled button, right-aligned with the button edge.
- Consolidated PDF cleanup: Removed the per-condition status badges (Confirmed / Awaiting Confirmation) from each condition's metadata card in the generated PDF. The single header-level badge already communicates overall status, making the per-condition badges redundant.
- Status column alignment: Right-aligned the Status column header and chip cells in the conditions table so the "Confirmed" chips sit flush with the right side of the table.
