### PR TITLE
CR-201:Consolidated Conditions pdf - Disclaimer updates

### DIFF
--- a/condition-api/src/condition_api/templates/consolidated_conditions.html
+++ b/condition-api/src/condition_api/templates/consolidated_conditions.html
@@ -46,9 +46,10 @@
     .page-disclaimer {
       position: running(page-disclaimer);
       background: #fee2e2;
+      border-radius: 4px;
       padding: 2mm 4mm;
-      font-size: 8pt;
-      color: #0a0a0a;
+      font-size: 14px;
+      color: #474543;
       line-height: 1.3;
     }
 


### PR DESCRIPTION
**Summary**

- Added border-radius: 4px to the red Disclaimer footer banner, matching the corner radius already applied to the yellow "For EAO use only" banner
- Increased the Disclaimer banner font size from 8pt to 14px for improved legibility
- Updated the Disclaimer banner font colour from #0a0a0a to #474543 to match the EAO banner's text colour
- 