### PR TITLE
CR-201:Consolidated Conditions pdf - Disclaimer updates

### DIFF
--- a/condition-api/src/condition_api/templates/consolidated_conditions.html
+++ b/condition-api/src/condition_api/templates/consolidated_conditions.html
@@ -407,7 +407,6 @@
 
   <div class="info-box">
     <p>This Consolidated Conditions document contains the most recent condition information as entered in the Condition Repository. This is not an official or enforceable document and should be used supplementary to official documents.</p>
-    <p><strong>Note:</strong> Conditions with the status &#8216;Awaiting Confirmation&#8217; have not been confirmed by a staff member.</p>
   </div>
 
   {% for condition in conditions %}


### PR DESCRIPTION
**Changes**
-Removeing "Note: Conditions with the status ‘Awaiting Confirmation’ have not been confirmed by a
staff member." from Consolidated Conditions PDF