### PR TITLE
CR-76:Add the ability to delete an attribute in the actions column

### DIFF
--- a/condition-api/src/condition_api/resources/condition_attribute.py
+++ b/condition-api/src/condition_api/resources/condition_attribute.py
@@ -84,3 +84,26 @@ class ConditionAttributeaResource(Resource):
             return 'Condition attribute successfully removed', HTTPStatus.OK
         except (KeyError, ValueError) as err:
             return {"message": str(err)}, HTTPStatus.BAD_REQUEST
+
+
+@cors_preflight("OPTIONS, DELETE")
+@API.route("/condition/<int:condition_id>/attribute/<int:attribute_id>", methods=["DELETE", "OPTIONS"])
+class ConditionSingleAttributeResource(Resource):
+    """Resource for deleting a single condition attribute."""
+
+    @staticmethod
+    @ApiHelper.swagger_decorators(API, endpoint_description="Delete a single condition attribute")
+    @API.response(code=HTTPStatus.OK, description="Delete a single condition attribute")
+    @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
+    @cross_origin(origins=allowedorigins())
+    @auth.has_one_of_roles([EpicConditionRole.MANAGE_CONDITIONS.value])
+    def delete(condition_id, attribute_id):
+        """Delete a single condition attribute by ID."""
+        try:
+            deleted = ConditionAttributeService.delete_single_condition_attribute(
+                condition_id, attribute_id)
+            if not deleted:
+                return 'No condition attribute found to remove', HTTPStatus.OK
+            return 'Condition attribute successfully removed', HTTPStatus.OK
+        except (KeyError, ValueError) as err:
+            return {"message": str(err)}, HTTPStatus.BAD_REQUEST

--- a/condition-api/src/condition_api/services/condition_attribute_service.py
+++ b/condition-api/src/condition_api/services/condition_attribute_service.py
@@ -331,6 +331,21 @@ class ConditionAttributeService:
         }
 
     @staticmethod
+    def delete_single_condition_attribute(condition_id, attribute_id):
+        """Delete a single condition attribute by ID."""
+        attribute = db.session.query(ConditionAttribute).filter_by(
+            id=attribute_id,
+            condition_id=condition_id
+        ).first()
+
+        if not attribute:
+            return False
+
+        db.session.delete(attribute)
+        db.session.commit()
+        return True
+
+    @staticmethod
     def delete_condition_attribute(condition_id, requires_management_plan=None):
         """Remove condition attribute and management plan data, and update condition flag if provided."""
         if requires_management_plan is not None:

--- a/condition-web/src/components/ConditionDetails/ConditionAttribute/Independent/ConditionAttributeRow.tsx
+++ b/condition-web/src/components/ConditionDetails/ConditionAttribute/Independent/ConditionAttributeRow.tsx
@@ -3,10 +3,12 @@ import { Button, IconButton, TableCell, TableRow, TableRowProps } from "@mui/mat
 import { CustomTooltip } from '../../../Shared/Common';
 import { styled } from "@mui/system";
 import EditIcon from "@mui/icons-material/Edit";
+import DeleteIcon from "@mui/icons-material/Delete";
 import { Save } from "@mui/icons-material";
 import RemoveIcon from '@mui/icons-material/Remove';
 import { BCDesignTokens } from "epic.theme";
 import { IndependentAttributeModel } from "@/models/ConditionAttribute";
+import DeleteConfirmationModal from "../ManagementPlan/DeleteConfirmationModal";
 import {
   CONDITION_KEYS,
   SELECT_OPTIONS,
@@ -47,6 +49,7 @@ export const ConditionAttributeHeadTableCell = styled(TableCell)(() => ({
 type ConditionAttributeRowProps = {
   conditionAttributeItem: IndependentAttributeModel;
   onSave: (updatedAttribute: IndependentAttributeModel) => void;
+  onDelete?: (attribute: IndependentAttributeModel) => void;
   is_approved?: boolean;
   onEditModeChange?: (isEditing: boolean) => void;
   isManagementRequired?: boolean;
@@ -57,6 +60,7 @@ type ConditionAttributeRowProps = {
 const ConditionAttributeRow: React.FC<ConditionAttributeRowProps> = ({
   conditionAttributeItem,
   onSave,
+  onDelete,
   is_approved,
   onEditModeChange,
   isManagementRequired,
@@ -66,6 +70,7 @@ const ConditionAttributeRow: React.FC<ConditionAttributeRowProps> = ({
   const canManage = useHasAllowedRoles([KeycloakRoles.MANAGE_CONDITIONS]);
   const { key: conditionKey, value: attributeValue } = conditionAttributeItem;
   const [isEditable, setIsEditable] = useState(false);
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [editableValue, setEditableValue] = useState(attributeValue ?? "");
   const [otherValue, setOtherValue] = useState("");
 
@@ -261,59 +266,76 @@ const ConditionAttributeRow: React.FC<ConditionAttributeRowProps> = ({
   };
 
   return (
-    <PackageTableRow>
-      <ConditionAttributeHeadTableCell align="left">
-        {conditionKey}
-        {(!attributeValue || attributeValue === "{}") && (
-          (isManagementRequired && managementRequiredKeys.includes(conditionKey)) ||
-          (isConsultationRequired && consultationRequiredKeys.includes(conditionKey)) ||
-          (isIEMRequired && iemRequiredKeys.includes(conditionKey))
-        ) && (
-          <CustomTooltip title="This attribute is required and cannot be empty" arrow>
-            <span style={{ color: "red", fontSize: "16px", marginLeft: "4px" }}>*</span>
-          </CustomTooltip>
-        )}
-      </ConditionAttributeHeadTableCell>
-      <ConditionAttributeHeadTableCell align="left">
-        {isEditable ? renderEditableField() : renderAttribute()}
-      </ConditionAttributeHeadTableCell>
-      <ConditionAttributeHeadTableCell
-        align="left"
-        sx={{
-          "&:hover": is_approved
-            ? {}
-            : {
-                backgroundColor: BCDesignTokens.themeGray70,
-              },
+    <>
+      <DeleteConfirmationModal
+        open={deleteModalOpen}
+        title="Delete Attribute?"
+        description={`This attribute will be removed from this submission requirement. It can be re-added under "Add Condition Attribute".<br/><br/>Are you sure you wish to proceed?`}
+        onClose={() => setDeleteModalOpen(false)}
+        onConfirm={() => {
+          setDeleteModalOpen(false);
+          onDelete?.(conditionAttributeItem);
         }}
-      >
-        {is_approved ? (
-          <IconButton size="small" disabled sx={{ cursor: "default" }}>
-            <RemoveIcon />
-          </IconButton>
-        ) : canManage ? (
-          isEditable ? (
-            <Button
-              variant="contained"
-              color="secondary"
-              size="small"
-              sx={{
-                borderRadius: "4px",
-                color: BCDesignTokens.themeGray100,
-              }}
-              onClick={handleSave}
-            >
-              <Save fontSize="small" sx={{ mr: 0.4 }}/>
-              Save
-            </Button>
-          ) : (
-            <IconButton size="small" onClick={() => setIsEditable(true)}>
-              <EditIcon />
+      />
+      <PackageTableRow>
+        <ConditionAttributeHeadTableCell align="left">
+          {conditionKey}
+          {(!attributeValue || attributeValue === "{}") && (
+            (isManagementRequired && managementRequiredKeys.includes(conditionKey)) ||
+            (isConsultationRequired && consultationRequiredKeys.includes(conditionKey)) ||
+            (isIEMRequired && iemRequiredKeys.includes(conditionKey))
+          ) && (
+            <CustomTooltip title="This attribute is required and cannot be empty" arrow>
+              <span style={{ color: "red", fontSize: "16px", marginLeft: "4px" }}>*</span>
+            </CustomTooltip>
+          )}
+        </ConditionAttributeHeadTableCell>
+        <ConditionAttributeHeadTableCell align="left">
+          {isEditable ? renderEditableField() : renderAttribute()}
+        </ConditionAttributeHeadTableCell>
+        <ConditionAttributeHeadTableCell
+          align="left"
+          sx={{
+            "&:hover": is_approved
+              ? {}
+              : {
+                  backgroundColor: BCDesignTokens.themeGray70,
+                },
+          }}
+        >
+          {is_approved ? (
+            <IconButton size="small" disabled sx={{ cursor: "default" }}>
+              <RemoveIcon />
             </IconButton>
-          )
-        ) : null}
-      </ConditionAttributeHeadTableCell>
-    </PackageTableRow>
+          ) : canManage ? (
+            isEditable ? (
+              <Button
+                variant="contained"
+                color="secondary"
+                size="small"
+                sx={{
+                  borderRadius: "4px",
+                  color: BCDesignTokens.themeGray100,
+                }}
+                onClick={handleSave}
+              >
+                <Save fontSize="small" sx={{ mr: 0.4 }}/>
+                Save
+              </Button>
+            ) : (
+              <>
+                <IconButton size="small" onClick={() => setIsEditable(true)}>
+                  <EditIcon />
+                </IconButton>
+                <IconButton size="small" onClick={() => setDeleteModalOpen(true)}>
+                  <DeleteIcon />
+                </IconButton>
+              </>
+            )
+          ) : null}
+        </ConditionAttributeHeadTableCell>
+      </PackageTableRow>
+    </>
   );
 };
 

--- a/condition-web/src/components/ConditionDetails/ConditionAttribute/Independent/ConditionAttributeTable.tsx
+++ b/condition-web/src/components/ConditionDetails/ConditionAttribute/Independent/ConditionAttributeTable.tsx
@@ -13,7 +13,7 @@ import {
 import AddIcon from '@mui/icons-material/Add';
 import { BCDesignTokens } from "epic.theme";
 import { theme } from "@/styles/theme";
-import { useUpdateConditionAttributeDetails } from "@/hooks/api/useConditionAttribute";
+import { useUpdateConditionAttributeDetails, useDeleteSingleConditionAttribute } from "@/hooks/api/useConditionAttribute";
 import { ConditionModel } from "@/models/Condition";
 import { IndependentAttributeModel } from "@/models/ConditionAttribute";
 import { notify } from "@/components/Shared/Snackbar/snackbarStore";
@@ -73,6 +73,18 @@ const ConditionAttributeTable = memo(({
       {
         onSuccess: onCreateSuccess,
         onError: onCreateFailure,
+      }
+    );
+
+    const { mutateAsync: deleteSingleAttribute } = useDeleteSingleConditionAttribute(
+      condition.condition_id,
+      {
+        onSuccess: () => {
+          notify.success("Attribute deleted successfully");
+          queryClient.invalidateQueries({ queryKey: ["conditions", condition.condition_id] });
+          queryClient.invalidateQueries({ queryKey: [QUERY_KEY.CONDITIONSDETAIL] });
+        },
+        onError: () => notify.error("Failed to delete attribute"),
       }
     );
   
@@ -166,6 +178,20 @@ const ConditionAttributeTable = memo(({
       const data: updateTopicTagsModel = {
         is_condition_attributes_approved: !condition.is_condition_attributes_approved }
       updateConditionDetails(data);
+    };
+
+    const handleDelete = async (attributeToDelete: IndependentAttributeModel) => {
+      await deleteSingleAttribute(Number(attributeToDelete.id));
+
+      setCondition((prevCondition) => ({
+        ...prevCondition,
+        condition_attributes: {
+          independent_attributes: (prevCondition.condition_attributes?.independent_attributes || []).filter(
+            (attr: IndependentAttributeModel) => attr.id !== attributeToDelete.id
+          ),
+          management_plans: prevCondition.condition_attributes?.management_plans || [],
+        },
+      }));
     };
 
     const handleSave = async (updatedAttribute: IndependentAttributeModel) => {
@@ -352,6 +378,7 @@ const ConditionAttributeTable = memo(({
                   key={attribute.id}
                   conditionAttributeItem={attribute}
                   onSave={handleSave}
+                  onDelete={handleDelete}
                   is_approved={condition.is_condition_attributes_approved}
                   onEditModeChange={(isEditing) => {
                     setIsAnyRowEditing(isEditing);

--- a/condition-web/src/components/ConditionDetails/ConditionAttribute/ManagementPlan/DeleteConfirmationModal.tsx
+++ b/condition-web/src/components/ConditionDetails/ConditionAttribute/ManagementPlan/DeleteConfirmationModal.tsx
@@ -22,6 +22,7 @@ type DeleteConfirmationModalProps = {
 const DeleteConfirmationModal: React.FC<DeleteConfirmationModalProps> = ({
   open,
   title = "Delete Management Plan",
+  description = "By deleting this Management Plan, you will lose all of its associated attributes.<br/><br/>Are you sure you wish to proceed?",
   onClose,
   onConfirm,
 }) => {
@@ -58,11 +59,7 @@ const DeleteConfirmationModal: React.FC<DeleteConfirmationModalProps> = ({
                 color: "#CE3E39",
                 fontSize: "14px"
             }}
-            dangerouslySetInnerHTML={{
-                __html: `
-                    By deleting this Management Plan, you will lose all of its associated attributes.<br/><br/>Are you sure you wish to proceed?
-                `,
-            }}
+            dangerouslySetInnerHTML={{ __html: description }}
         />
             <DialogActions>
                 <Button color="secondary" onClick={onClose}>

--- a/condition-web/src/hooks/api/useConditionAttribute.tsx
+++ b/condition-web/src/hooks/api/useConditionAttribute.tsx
@@ -35,6 +35,28 @@ export const useUpdateConditionAttributeDetails = (
   });
 };
 
+const deleteSingleConditionAttribute = (conditionId: number, attributeId: number) => {
+  return submitRequest({
+    url: `/attributes/condition/${conditionId}/attribute/${attributeId}`,
+    method: "delete",
+  });
+};
+
+export const useDeleteSingleConditionAttribute = (
+  conditionId?: number,
+  options?: Options
+) => {
+  return useMutation({
+    mutationFn: (attributeId: number) => {
+      if (!conditionId) {
+        return Promise.reject(new Error("Condition ID is required"));
+      }
+      return deleteSingleConditionAttribute(conditionId, attributeId);
+    },
+    ...options,
+  });
+};
+
 const removeConditionAttributes = (
   conditionId: number,
   requiresManagementPlan: boolean


### PR DESCRIPTION
**Summary**:
Adds the ability to remove an optional attribute from a condition's attribute list.
**Changes**:

- Trash icon added beside the edit icon on each attribute row (visible to managers, hidden when approved)
- Confirmation modal prompts the user before deletion ("Delete Attribute?" with Cancel/Confirm)
- New backend endpoint DELETE /attributes/condition/<id>/attribute/<attr_id> to delete a single attribute by ID
- New useDeleteSingleConditionAttribute frontend hook wired to the new endpoint
- Deleted attributes become available again under "Add Condition Attribute"
- Fixed DeleteConfirmationModal to render its description prop (was previously ignored)