### PR TITLE
CR-203:Adding Amendments to an Exemption Order from the Project page

### DIFF
--- a/condition-api/migrations/versions/a1b2c3d4e5f6_document_type_many_to_many_categories.py
+++ b/condition-api/migrations/versions/a1b2c3d4e5f6_document_type_many_to_many_categories.py
@@ -1,0 +1,186 @@
+"""document_type_many_to_many_categories
+
+Revision ID: a1b2c3d4e5f6
+Revises: 9c1f2d3e4a5b
+Create Date: 2026-07-08
+
+Replace single document_category_id FK on document_types with a many-to-many
+junction table (document_type_categories). Also adds document_category_id
+directly onto documents so each document record explicitly owns its category.
+
+Written to be idempotent — safe to re-run if the DB is in a partial state.
+"""
+from alembic import op
+
+revision = 'a1b2c3d4e5f6'
+down_revision = '9c1f2d3e4a5b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # ------------------------------------------------------------------ #
+    # Step 1: Add document_category_id to documents (idempotent)         #
+    # ------------------------------------------------------------------ #
+    op.execute("""
+        ALTER TABLE condition.documents
+        ADD COLUMN IF NOT EXISTS document_category_id INTEGER;
+    """)
+
+    op.execute("""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'fk_documents_document_category_id'
+            ) THEN
+                ALTER TABLE condition.documents
+                ADD CONSTRAINT fk_documents_document_category_id
+                FOREIGN KEY (document_category_id)
+                REFERENCES condition.document_categories(id)
+                ON DELETE RESTRICT;
+            END IF;
+        END;
+        $$;
+    """)
+
+    # ------------------------------------------------------------------ #
+    # Step 2: Backfill from existing document_types.document_category_id  #
+    # Only fills rows that are still NULL (safe to re-run).               #
+    # ------------------------------------------------------------------ #
+    op.execute("""
+        UPDATE condition.documents d
+        SET document_category_id = dt.document_category_id
+        FROM condition.document_types dt
+        WHERE d.document_type_id = dt.id
+          AND d.document_category_id IS NULL
+          AND EXISTS (
+              SELECT 1 FROM information_schema.columns
+              WHERE table_schema = 'condition'
+                AND table_name   = 'document_types'
+                AND column_name  = 'document_category_id'
+          );
+    """)
+
+    # ------------------------------------------------------------------ #
+    # Step 3: Create junction table (idempotent)                          #
+    # ------------------------------------------------------------------ #
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS condition.document_type_categories (
+            id                   SERIAL PRIMARY KEY,
+            document_type_id     INTEGER NOT NULL
+                REFERENCES condition.document_types(id) ON DELETE CASCADE,
+            document_category_id INTEGER NOT NULL
+                REFERENCES condition.document_categories(id) ON DELETE CASCADE,
+            created_date         TIMESTAMP NOT NULL DEFAULT NOW(),
+            updated_date         TIMESTAMP,
+            created_by           VARCHAR(50),
+            updated_by           VARCHAR(50),
+            CONSTRAINT uq_document_type_category
+                UNIQUE (document_type_id, document_category_id)
+        );
+    """)
+
+    # ------------------------------------------------------------------ #
+    # Step 4: Seed junction table (idempotent via ON CONFLICT DO NOTHING) #
+    # ------------------------------------------------------------------ #
+    op.execute("""
+        INSERT INTO condition.document_type_categories
+            (document_type_id, document_category_id, created_date, updated_date)
+        VALUES
+            (1, 1, NOW(), NOW()),  -- Certificate          → Certificate and Amendments
+            (2, 2, NOW(), NOW()),  -- Exemption Order      → Exemption Order and Amendments
+            (3, 1, NOW(), NOW()),  -- Amendment            → Certificate and Amendments
+            (3, 2, NOW(), NOW()),  -- Amendment            → Exemption Order and Amendments (NEW)
+            (4, 3, NOW(), NOW())   -- Other Order          → Other Orders
+        ON CONFLICT (document_type_id, document_category_id) DO NOTHING;
+    """)
+
+    # Grant table permissions
+    op.execute("""
+        GRANT SELECT, INSERT, UPDATE, DELETE
+        ON condition.document_type_categories TO condition;
+    """)
+    op.execute("""
+        GRANT USAGE, SELECT, UPDATE
+        ON SEQUENCE condition.document_type_categories_id_seq TO condition;
+    """)
+
+    # ------------------------------------------------------------------ #
+    # Step 5: Drop document_category_id from document_types (idempotent) #
+    # ------------------------------------------------------------------ #
+    op.execute("""
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'document_types_document_category_id_fkey'
+            ) THEN
+                ALTER TABLE condition.document_types
+                DROP CONSTRAINT document_types_document_category_id_fkey;
+            END IF;
+        END;
+        $$;
+    """)
+
+    op.execute("""
+        ALTER TABLE condition.document_types
+        DROP COLUMN IF EXISTS document_category_id;
+    """)
+
+
+def downgrade():
+    op.execute("""
+        ALTER TABLE condition.document_types
+        ADD COLUMN IF NOT EXISTS document_category_id INTEGER;
+    """)
+
+    op.execute("""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'document_types_document_category_id_fkey'
+            ) THEN
+                ALTER TABLE condition.document_types
+                ADD CONSTRAINT document_types_document_category_id_fkey
+                FOREIGN KEY (document_category_id)
+                REFERENCES condition.document_categories(id)
+                ON DELETE CASCADE;
+            END IF;
+        END;
+        $$;
+    """)
+
+    # Restore from first junction entry per document type
+    op.execute("""
+        UPDATE condition.document_types dt
+        SET document_category_id = (
+            SELECT dtc.document_category_id
+            FROM condition.document_type_categories dtc
+            WHERE dtc.document_type_id = dt.id
+            ORDER BY dtc.id
+            LIMIT 1
+        );
+    """)
+
+    op.execute("DROP TABLE IF EXISTS condition.document_type_categories;")
+
+    op.execute("""
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'fk_documents_document_category_id'
+            ) THEN
+                ALTER TABLE condition.documents
+                DROP CONSTRAINT fk_documents_document_category_id;
+            END IF;
+        END;
+        $$;
+    """)
+
+    op.execute("""
+        ALTER TABLE condition.documents
+        DROP COLUMN IF EXISTS document_category_id;
+    """)

--- a/condition-api/src/condition_api/models/__init__.py
+++ b/condition-api/src/condition_api/models/__init__.py
@@ -24,6 +24,7 @@ from .db import db, ma, migrate
 from .document import Document
 from .document_category import DocumentCategory
 from .document_type import DocumentType
+from .document_type_category import DocumentTypeCategory
 from .management_plan import ManagementPlan
 from .project import Project
 from .staff_user import StaffUser

--- a/condition-api/src/condition_api/models/document.py
+++ b/condition-api/src/condition_api/models/document.py
@@ -21,6 +21,7 @@ class Document(BaseModel):
     document_id = Column(String(255), nullable=False)
     amended_id = Column(Integer, ForeignKey('condition.documents.id', ondelete='CASCADE'), nullable=True)
     document_type_id = Column(Integer, ForeignKey('condition.document_types.id', ondelete='CASCADE'), nullable=True)
+    document_category_id = Column(Integer, ForeignKey('condition.document_categories.id', ondelete='RESTRICT'), nullable=True)
     document_label = Column(Text)
     document_link = Column(Text)
     document_file_name = Column(Text)

--- a/condition-api/src/condition_api/models/document.py
+++ b/condition-api/src/condition_api/models/document.py
@@ -21,7 +21,9 @@ class Document(BaseModel):
     document_id = Column(String(255), nullable=False)
     amended_id = Column(Integer, ForeignKey('condition.documents.id', ondelete='CASCADE'), nullable=True)
     document_type_id = Column(Integer, ForeignKey('condition.document_types.id', ondelete='CASCADE'), nullable=True)
-    document_category_id = Column(Integer, ForeignKey('condition.document_categories.id', ondelete='RESTRICT'), nullable=True)
+    document_category_id = Column(
+        Integer, ForeignKey('condition.document_categories.id', ondelete='RESTRICT'), nullable=True
+    )
     document_label = Column(Text)
     document_link = Column(Text)
     document_file_name = Column(Text)

--- a/condition-api/src/condition_api/models/document_category.py
+++ b/condition-api/src/condition_api/models/document_category.py
@@ -4,6 +4,7 @@ Manages the Document Category
 """
 from sqlalchemy import Column, Integer, String
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import relationship
 
 from .base_model import BaseModel
 
@@ -17,6 +18,12 @@ class DocumentCategory(BaseModel):
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     category_name = Column(String(255), nullable=False)
+
+    document_type_categories = relationship(
+        'DocumentTypeCategory',
+        back_populates='document_category',
+        lazy='select'
+    )
 
     __table_args__ = (
         {'schema': 'condition'}

--- a/condition-api/src/condition_api/models/document_type.py
+++ b/condition-api/src/condition_api/models/document_type.py
@@ -2,8 +2,9 @@
 
 Manages the Document Type
 """
-from sqlalchemy import Column, ForeignKey, Integer, String
+from sqlalchemy import Column, Integer, String
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import joinedload, relationship
 
 from .base_model import BaseModel
 
@@ -16,21 +17,37 @@ class DocumentType(BaseModel):
     __tablename__ = 'document_types'
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    document_category_id = Column(Integer,
-                                  ForeignKey('condition.document_categories.id',
-                                             ondelete='CASCADE'), nullable=True)
     document_type = Column(String(255), nullable=False)
+
+    document_type_categories = relationship(
+        'DocumentTypeCategory',
+        back_populates='document_type',
+        lazy='select'
+    )
 
     __table_args__ = (
         {'schema': 'condition'}
     )
 
+    @property
+    def categories(self):
+        """Return the list of DocumentCategory objects for this type."""
+        return [dtc.document_category for dtc in self.document_type_categories]
+
     @classmethod
     def get_all(cls):
-        """Get all document types."""
-        return cls.query.all()
+        """Get all document types with their categories eagerly loaded."""
+        from .document_type_category import DocumentTypeCategory  # avoid circular import
+        return (
+            cls.query
+            .options(
+                joinedload(cls.document_type_categories)
+                .joinedload(DocumentTypeCategory.document_category)
+            )
+            .all()
+        )
 
     @classmethod
     def get_by_id(cls, document_id):
-        """Get document by document_id."""
+        """Get document type by id."""
         return cls.query.filter_by(id=document_id).first()

--- a/condition-api/src/condition_api/models/document_type.py
+++ b/condition-api/src/condition_api/models/document_type.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import joinedload, relationship
 
 from .base_model import BaseModel
+from .document_type_category import DocumentTypeCategory
 
 Base = declarative_base()
 
@@ -37,7 +38,6 @@ class DocumentType(BaseModel):
     @classmethod
     def get_all(cls):
         """Get all document types with their categories eagerly loaded."""
-        from .document_type_category import DocumentTypeCategory  # avoid circular import
         return (
             cls.query
             .options(

--- a/condition-api/src/condition_api/models/document_type_category.py
+++ b/condition-api/src/condition_api/models/document_type_category.py
@@ -1,0 +1,38 @@
+"""DocumentTypeCategory junction model.
+
+Many-to-many link between document_types and document_categories.
+"""
+from sqlalchemy import Column, ForeignKey, Integer, UniqueConstraint
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import relationship
+
+from .base_model import BaseModel
+
+Base = declarative_base()
+
+
+class DocumentTypeCategory(BaseModel):
+    """Junction table linking a document type to one or more categories."""
+
+    __tablename__ = 'document_type_categories'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    document_type_id = Column(
+        Integer,
+        ForeignKey('condition.document_types.id', ondelete='CASCADE'),
+        nullable=False
+    )
+    document_category_id = Column(
+        Integer,
+        ForeignKey('condition.document_categories.id', ondelete='CASCADE'),
+        nullable=False
+    )
+
+    document_type = relationship('DocumentType', back_populates='document_type_categories')
+    document_category = relationship('DocumentCategory', back_populates='document_type_categories')
+
+    __table_args__ = (
+        UniqueConstraint('document_type_id', 'document_category_id',
+                         name='uq_document_type_category'),
+        {'schema': 'condition'}
+    )

--- a/condition-api/src/condition_api/schemas/document.py
+++ b/condition-api/src/condition_api/schemas/document.py
@@ -18,12 +18,19 @@ class DocumentLabelSchema(Schema):
     project_type = fields.Str(data_key="project_type", allow_none=True)
 
 
+class DocumentCategorySchema(Schema):
+    """Document category schema (used as nested in DocumentTypeSchema)."""
+
+    id = fields.Int(data_key="id")
+    category_name = fields.Str(data_key="category_name")
+
+
 class DocumentTypeSchema(Schema):
     """Documents type schema."""
 
     id = fields.Int(data_key="id")
-    document_category_id = fields.Int(data_key="document_category_id")
     document_type = fields.Str(data_key="document_type")
+    categories = fields.List(fields.Nested(DocumentCategorySchema), data_key="categories")
 
 
 class DocumentSchema(Schema):
@@ -34,7 +41,7 @@ class DocumentSchema(Schema):
     document_label = fields.Str(data_key="document_label")
     document_link = fields.Str(data_key="document_link")
     document_file_name = fields.Str(data_key="document_file_name")
-    document_category_id = fields.Str(data_key="document_category_id")
+    document_category_id = fields.Int(data_key="document_category_id", load_default=None)
     document_category = fields.Str(data_key="document_category")
     document_types = fields.List(fields.Str(), data_key="document_types")
     document_type_id = fields.Int(data_key="document_type_id")

--- a/condition-api/src/condition_api/services/condition_service.py
+++ b/condition-api/src/condition_api/services/condition_service.py
@@ -708,12 +708,11 @@ class ConditionService:
             db.session.query(
                 Project.project_id,
                 Project.project_name,
-                DocumentType.document_category_id,
+                Document.document_category_id,
                 DocumentCategory.category_name.label("document_category")
             )
             .outerjoin(Document, Project.project_id == Document.project_id)
-            .outerjoin(DocumentType, DocumentType.id == Document.document_type_id)
-            .outerjoin(DocumentCategory, DocumentCategory.id == DocumentType.document_category_id)
+            .outerjoin(DocumentCategory, DocumentCategory.id == Document.document_category_id)
             .filter(Document.document_id == condition_data.document_id)
             .first()
         )
@@ -890,8 +889,7 @@ class ConditionService:
                     )
                     .select_from(Project)
                     .join(Document, Document.project_id == Project.project_id)
-                    .join(DocumentType, DocumentType.id == Document.document_type_id)
-                    .join(DocumentCategory, DocumentCategory.id == DocumentType.document_category_id)
+                    .join(DocumentCategory, DocumentCategory.id == Document.document_category_id)
                     .join(Amendment, Amendment.document_id == Document.id)
                     .join(Condition, Condition.amended_document_id == Amendment.amended_document_id)
                     .filter(filter_condition)
@@ -918,8 +916,7 @@ class ConditionService:
                     )
                     .select_from(Project)
                     .join(Document, Document.project_id == Project.project_id)
-                    .join(DocumentType, DocumentType.id == Document.document_type_id)
-                    .join(DocumentCategory, DocumentCategory.id == DocumentType.document_category_id)
+                    .join(DocumentCategory, DocumentCategory.id == Document.document_category_id)
                     .join(Amendment, Amendment.document_id == Document.id)
                     .join(Condition, Condition.amended_document_id == Amendment.amended_document_id)
                     .filter(filter_condition)
@@ -958,8 +955,7 @@ class ConditionService:
                 Amendment.amendment_name
             )
             .join(Document, Document.project_id == Project.project_id)
-            .join(DocumentType, DocumentType.id == Document.document_type_id)
-            .join(DocumentCategory, DocumentCategory.id == DocumentType.document_category_id)
+            .join(DocumentCategory, DocumentCategory.id == Document.document_category_id)
             .join(Condition, Condition.document_id == Document.document_id)
             .outerjoin(Amendment, Amendment.amended_document_id == Condition.amended_document_id)
             .outerjoin(
@@ -1330,16 +1326,28 @@ class ConditionService:
         document_categories = aliased(DocumentCategory)
         conditions = aliased(Condition)
         subconditions = aliased(Subcondition)
+        parent_docs = aliased(Document)
 
-        document_join, document_type_join, document_label_col, date_col, document_filter, doc_entity =\
+        document_join, _, document_label_col, date_col, document_filter, doc_entity =\
             ConditionService._get_document_joins_and_columns(
                 is_amendment, base_document_info, document_id,
                 document_types, conditions
             )
 
+        if is_amendment:
+            # Category lives on the parent document (Amendment.document_id → Document)
+            category_id_col = parent_docs.document_category_id.label("document_category_id")
+            parent_doc_join = parent_docs.id == doc_entity.document_id
+            category_join = document_categories.id == parent_docs.document_category_id
+        else:
+            # Category lives directly on the document
+            category_id_col = doc_entity.document_category_id.label("document_category_id")
+            parent_doc_join = None
+            category_join = document_categories.id == doc_entity.document_category_id
+
         query = (
             db.session.query(
-                document_types.document_category_id,
+                category_id_col,
                 document_categories.category_name.label("document_category"),
                 document_label_col,
                 conditions.id,
@@ -1363,8 +1371,14 @@ class ConditionService:
             )
             .outerjoin(subconditions, conditions.id == subconditions.condition_id)
             .outerjoin(doc_entity, document_join)
-            .outerjoin(document_types, document_type_join)
-            .outerjoin(document_categories, document_categories.id == document_types.document_category_id)
+        )
+
+        if is_amendment:
+            query = query.outerjoin(parent_docs, parent_doc_join)
+
+        query = (
+            query
+            .outerjoin(document_categories, category_join)
             .filter(document_filter, conditions.id == condition_id)
             .order_by(subconditions.sort_order)
         )

--- a/condition-api/src/condition_api/services/document_service.py
+++ b/condition-api/src/condition_api/services/document_service.py
@@ -91,11 +91,8 @@ class DocumentService:
             Project,
             Project.project_id == Document.project_id
         ).outerjoin(
-            DocumentTypeModel,
-            DocumentTypeModel.id == Document.document_type_id
-        ).outerjoin(
             DocumentCategory,
-            DocumentCategory.id == DocumentTypeModel.document_category_id
+            DocumentCategory.id == Document.document_category_id
         ).outerjoin(
             Condition,
             and_(
@@ -104,7 +101,7 @@ class DocumentService:
             )
         ).filter(
             (Project.project_id == project_id)
-            & (DocumentCategory.id == category_id)
+            & (Document.document_category_id == category_id)
             & (Document.is_active.is_(True))
         ).group_by(
             Project.project_name,
@@ -220,6 +217,7 @@ class DocumentService:
             document_label=document.get("document_label"),
             document_link=document.get("document_link"),
             document_type_id=document.get("document_type_id"),
+            document_category_id=document.get("document_category_id"),
             is_latest_amendment_added=document.get("is_latest_amendment_added"),
             is_active=True
         )
@@ -248,6 +246,7 @@ class DocumentService:
         existing_document.document_label = document.get("document_label")
         existing_document.document_link = document.get("document_link")
         existing_document.document_type_id = document.get("document_type_id")
+        existing_document.document_category_id = document.get("document_category_id")
         existing_document.date_issued = date_issued
         existing_document.is_latest_amendment_added = document.get("is_latest_amendment_added")
         existing_document.is_active = document.get("is_active")
@@ -355,13 +354,13 @@ class DocumentService:
             amendment_detail = (
                 db.session.query(
                     Project.project_name.label('project_name'),
-                    DocumentCategory.id.label('document_category_id'),
+                    Document.document_category_id.label('document_category_id'),
                     DocumentCategory.category_name.label('document_category'),
                     extract("year", Amendment.date_issued).label('year_issued')
                 )
-                .outerjoin(Document, Document.project_id == Project.project_id)
-                .outerjoin(DocumentTypeModel, DocumentTypeModel.id == Document.document_type_id)
-                .outerjoin(DocumentCategory, DocumentCategory.id == DocumentTypeModel.document_category_id)
+                .select_from(Document)
+                .outerjoin(DocumentCategory, DocumentCategory.id == Document.document_category_id)
+                .outerjoin(Project, Project.project_id == Document.project_id)
                 .outerjoin(Amendment, Amendment.amended_document_id == document_id)
                 .filter(Document.id == is_amendment_document.document_id)
                 .first()
@@ -372,7 +371,7 @@ class DocumentService:
             document = (
                 db.session.query(
                     Project.project_name.label('project_name'),
-                    DocumentCategory.id.label('document_category_id'),
+                    Document.document_category_id.label('document_category_id'),
                     DocumentCategory.category_name.label('document_category'),
                     Document.document_id.label('document_id'),
                     Document.document_label.label('document_label'),
@@ -381,7 +380,7 @@ class DocumentService:
                 )
                 .outerjoin(Project, Project.project_id == Document.project_id)
                 .outerjoin(DocumentTypeModel, DocumentTypeModel.id == Document.document_type_id)
-                .outerjoin(DocumentCategory, DocumentCategory.id == DocumentTypeModel.document_category_id)
+                .outerjoin(DocumentCategory, DocumentCategory.id == Document.document_category_id)
                 .filter(Document.document_id == document_id)
                 .first()
             )

--- a/condition-api/src/condition_api/services/project_service.py
+++ b/condition-api/src/condition_api/services/project_service.py
@@ -21,7 +21,7 @@ from condition_api.models.amendment import Amendment
 from condition_api.models.condition import Condition
 from condition_api.models.db import db
 from condition_api.models.document import Document
-from condition_api.models.document_category import DocumentCategory
+from condition_api.models.document_category import DocumentCategory  # used in get_all_projects group_by
 from condition_api.models.document_type import DocumentType
 from condition_api.models.project import Project
 
@@ -46,7 +46,7 @@ class ProjectService:
             )
             .outerjoin(Document, and_(Document.project_id == Project.project_id, Document.is_active.is_(True)))
             .outerjoin(DocumentType, DocumentType.id == Document.document_type_id)
-            .outerjoin(DocumentCategory, DocumentCategory.id == DocumentType.document_category_id)
+            .outerjoin(DocumentCategory, DocumentCategory.id == Document.document_category_id)
             .outerjoin(Amendment, Amendment.document_id == Document.id)
             .filter(Project.is_active.is_(True))
             .group_by(
@@ -97,11 +97,9 @@ class ProjectService:
         # Fetch all documents for the project
         documents = (
             db.session.query(Document.id, Document.document_id)
-            .join(DocumentType, DocumentType.id == Document.document_type_id)
-            .join(DocumentCategory, DocumentCategory.id == DocumentType.document_category_id)
             .filter(and_(
                 Document.project_id == project_id,
-                DocumentCategory.id == document_category_id,
+                Document.document_category_id == document_category_id,
                 Document.is_active.is_(True)
             ))
             .all()
@@ -173,12 +171,10 @@ class ProjectService:
                     )
                 ).label("all_approved"))
             .join(Document, Document.document_id == Condition.document_id)
-            .join(DocumentType, DocumentType.id == Document.document_type_id)
-            .join(DocumentCategory, DocumentCategory.id == DocumentType.document_category_id)
             .filter(
                 and_(
                     Document.project_id == project_id,
-                    DocumentCategory.id == document_category_id
+                    Document.document_category_id == document_category_id
                 )
             )
             .filter(

--- a/condition-api/tests/utilities/factory_utils.py
+++ b/condition-api/tests/utilities/factory_utils.py
@@ -27,6 +27,7 @@ from condition_api.models import (
     Document,
     DocumentCategory,
     DocumentType,
+    DocumentTypeCategory,
     ManagementPlan,
     Project,
     StaffUser,
@@ -84,19 +85,26 @@ def factory_document_category_model(name="Exemption Order and Amendments"):
 
 
 def factory_document_type_model(category, name="Certificate"):
-    """Document Type"""
-    doc_type = DocumentType(document_type=name, document_category_id=category.id)
+    """Document Type — creates the type and its junction entry for the given category."""
+    doc_type = DocumentType(document_type=name)
     db.session.add(doc_type)
+    db.session.flush()
+    junction = DocumentTypeCategory(
+        document_type_id=doc_type.id,
+        document_category_id=category.id
+    )
+    db.session.add(junction)
     db.session.commit()
     return doc_type
 
 
-def factory_document_model(project_id, document_type_id, is_latest=True, is_active=True):
+def factory_document_model(project_id, document_type_id, document_category_id=None, is_latest=True, is_active=True):
     """Document"""
     document = Document(
         document_id=str(uuid.uuid4()),
         project_id=project_id,
         document_type_id=document_type_id,
+        document_category_id=document_category_id,
         document_label="Label A",
         document_file_name="test.pdf",
         is_latest_amendment_added=is_latest,

--- a/condition-loader/loadConditions.py
+++ b/condition-loader/loadConditions.py
@@ -43,16 +43,26 @@ def insert_subconditions(condition_id, parent_subcondition_id, subconditions):
         if 'subconditions' in subcondition and subcondition['subconditions']:
             insert_subconditions(condition_id, subcondition_id, subcondition['subconditions'])
 
+def get_document_type_id(document_type):
+    """Return document_type_id from document_types table based on type string."""
+    mapping = {
+        "Exemption Order": 2,
+        "Other Order": 4,
+        "Amendment": 3,
+        "Schedule B/Certificate": 1,
+    }
+    return mapping.get(document_type)
+
+
 def get_document_category_id(document_type):
-    """Determine the document_category_id based on document_type."""
-    if document_type == "Exemption Order":
-        return 2
-    elif document_type == "Other Order":
-        return 4
-    elif document_type == "Amendment":
-        return 3
-    elif document_type == "Schedule B/Certificate":
-        return 1
+    """Return document_category_id from document_categories table based on type string."""
+    mapping = {
+        "Exemption Order": 2,
+        "Other Order": 3,
+        "Amendment": 1,
+        "Schedule B/Certificate": 1,
+    }
+    return mapping.get(document_type)
 
 def load_data(folder_path):
     for filename in os.listdir(folder_path):
@@ -66,8 +76,8 @@ def load_data(folder_path):
             document_id = data['document_id']
             document_type = data['document_type']
 
-            # Determine document_category_id
-            document_type_id = get_document_category_id(document_type)
+            document_type_id = get_document_type_id(document_type)
+            document_category_id = get_document_category_id(document_type)
 
             # Check if the record already exists in the 'documents' table
             cur.execute("""
@@ -88,11 +98,11 @@ def load_data(folder_path):
             # Insert into the 'documents' table
             cur.execute("""
                 INSERT INTO condition.documents (
-                    document_id, document_type_id, document_label, document_file_name, 
+                    document_id, document_type_id, document_category_id, document_label, document_file_name,
                     date_issued, act, first_nations, consultation_records_required, project_id, created_date
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, NOW())
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, NOW())
             """, (
-                document_id, document_type_id, data['display_name'],
+                document_id, document_type_id, document_category_id, data['display_name'],
                 data['document_file_name'], data['date_issued'], data['act'],
                 convert_to_pg_array(data.get('first_nations', [])),
                 data.get('consultation_records_required', False), project_id

--- a/condition-loader/loaders/document_loader.py
+++ b/condition-loader/loaders/document_loader.py
@@ -1,4 +1,4 @@
-from utils import convert_to_pg_array, get_document_category_id
+from utils import convert_to_pg_array, get_document_type_id, get_document_category_id
 
 def insert_project(cur, project_id, project_name, project_type):
     cur.execute("""
@@ -19,12 +19,13 @@ def insert_document(cur, data, project_id):
 
     cur.execute("""
         INSERT INTO condition.documents (
-            document_id, document_type_id, document_label, document_link,
+            document_id, document_type_id, document_category_id, document_label, document_link,
             document_file_name, date_issued, act, first_nations,
             consultation_records_required, is_latest_amendment_added, project_id, created_date
-        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, NOW())
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, NOW())
     """, (
         doc_id,
+        get_document_type_id(data['document_type']),
         get_document_category_id(data['document_type']),
         data['display_name'],
         data.get('document_link'),

--- a/condition-loader/utils.py
+++ b/condition-loader/utils.py
@@ -4,12 +4,30 @@ def convert_to_pg_array(json_array):
     """Convert JSON array to PostgreSQL array format."""
     return '{' + ','.join(json.dumps(item) for item in json_array) + '}'
 
-def get_document_category_id(document_type):
+def get_document_type_id(document_type):
     """Return document_type_id based on type string."""
     mapping = {
         "Exemption Order": 2,
         "Other Order": 4,
         "Amendment": 3,
+        "Schedule B/Certificate": 1
+    }
+    return mapping.get(document_type)
+
+
+def get_document_category_id(document_type):
+    """Return document_category_id based on type string.
+
+    Certificate/Amendment → category 1 (Certificate and Amendments)
+    Exemption Order       → category 2 (Exemption Order and Amendments)
+    Other Order           → category 3 (Other Orders)
+    Amendment loaded via the loader is always under Certificate and Amendments
+    because the loader pre-dates multi-category support. Override at load time if needed.
+    """
+    mapping = {
+        "Exemption Order": 2,
+        "Other Order": 3,
+        "Amendment": 1,
         "Schedule B/Certificate": 1
     }
     return mapping.get(document_type)

--- a/condition-web/cypress/utils/mockConstants.tsx
+++ b/condition-web/cypress/utils/mockConstants.tsx
@@ -102,10 +102,10 @@ export const mockProjects = [
 ];
 
 export const mockDocumentTypes = [
-  { document_category_id: 1, document_type: "Certificate", id: 1 },
-  { document_category_id: 2, document_type: "Exemption Order", id: 2 },
-  { document_category_id: 1, document_type: "Amendment", id: 3 },
-  { document_category_id: 3, document_type: "Other Order", id: 4 },
+  { id: 1, document_type: "Certificate", categories: [{ id: 1, category_name: "Certificate and Amendments" }] },
+  { id: 2, document_type: "Exemption Order", categories: [{ id: 2, category_name: "Exemption Order and Amendments" }] },
+  { id: 3, document_type: "Amendment", categories: [{ id: 1, category_name: "Certificate and Amendments" }, { id: 2, category_name: "Exemption Order and Amendments" }] },
+  { id: 4, document_type: "Other Order", categories: [{ id: 3, category_name: "Other Orders" }] },
 ];
 
 export const mockCategoryData = {

--- a/condition-web/src/components/Documents/DocumentEntryForm.tsx
+++ b/condition-web/src/components/Documents/DocumentEntryForm.tsx
@@ -126,14 +126,14 @@ export const DocumentEntryForm = ({
     };
 
     const filteredDocumentTypes = (documentType || []).filter((type) => {
-        if (restrictToCategoryId !== null && type.document_category_id !== restrictToCategoryId) return false;
+        if (restrictToCategoryId !== null && !type.categories?.some(c => c.id === restrictToCategoryId)) return false;
         if (!formState.selectedProject || !formState.selectedProject.documents) return true;
 
         const hasCertificate = formState.selectedProject.documents.some((document) =>
-            document.document_types.includes(DocumentType.Certificate)
+            document.document_types?.includes(DocumentType.Certificate)
         );
         const hasExemptionOrder = formState.selectedProject.documents.some((document) =>
-            document.document_types.includes(DocumentType.ExemptionOrder)
+            document.document_types?.includes(DocumentType.ExemptionOrder)
         );
 
         if (type.document_type === DocumentType.Certificate) return !hasExemptionOrder;
@@ -219,6 +219,9 @@ export const DocumentEntryForm = ({
             isLatestAmendment: formState.selectedDocumentType === DocumentTypes.OtherOrder,
         });
 
+        const selectedType = filteredDocumentTypes.find(t => t.id === formState.selectedDocumentType);
+        const resolvedCategoryId = restrictToCategoryId ?? selectedType?.categories?.[0]?.id ?? null;
+
         const payload = isAmendment
             ? {
                 amendment_name: formState.documentLabel,
@@ -230,6 +233,7 @@ export const DocumentEntryForm = ({
                 document_label: formState.documentLabel,
                 document_link: formState.documentLink,
                 document_type_id: formState.selectedDocumentType,
+                document_category_id: resolvedCategoryId,
                 date_issued: formattedDateIssued,
                 is_latest_amendment_added: formState.isLatestAmendment,
                 is_active: true,

--- a/condition-web/src/models/Document.ts
+++ b/condition-web/src/models/Document.ts
@@ -55,14 +55,15 @@ export interface ProjectDocumentAllAmendmentsModel {
 
 export interface DocumentTypeModel {
   id: number;
-  document_category_id: number;
   document_type: string;
+  categories: DocumentCategoryModel[];
 }
 
 export interface CreateDocumentModel {
   document_label: string | null;
   document_link: string | null;
   document_type_id?: number | null;
+  document_category_id?: number | null;
   date_issued?: string | null;
   is_latest_amendment_added?: boolean | null;
   is_active?: boolean;


### PR DESCRIPTION
### Problem
The "Add Document" dropdown was only showing Exemption Order on the Exemption Order category page, and Amendment was invisible. This was because document_types.document_category_id was a single FK, restricting each document type to exactly one category. Amendment belonged to category 1 (Certificate and Amendments), so it never appeared in category 2 (Exemption Order and Amendments).

**Solution**
Replaced the single FK on document_types with a many-to-many junction table (document_type_categories), and moved category ownership to the documents table so each document record explicitly knows which category it belongs to.

### Changes
**Database / Migration** (a1b2c3d4e5f6)

- Adds document_category_id column to documents table and backfills it from the existing document_types.document_category_id FK
- Creates document_type_categories junction table with a unique constraint per (document_type_id, document_category_id) pair
- Seeds all existing type→category relationships, plus the new Amendment → Exemption Order and Amendments entry
- Drops the now-redundant document_category_id column from document_types


**Backend**

- New DocumentTypeCategory model and relationship wired into DocumentType and DocumentCategory
- DocumentType.get_all() now eager-loads categories via joinedload through the junction table
- All service queries (document_service, project_service, condition_service) updated to join DocumentCategory via Document.document_category_id instead of DocumentType.document_category_id
- Schema updated: DocumentTypeSchema now serializes categories: [{ id, category_name }] instead of a flat document_category_id


**Frontend**

- DocumentTypeModel updated from document_category_id: number to categories: DocumentCategoryModel[]
- DocumentEntryForm filter changed from type.document_category_id !== restrictToCategoryId to type.categories?.some(c => c.id === restrictToCategoryId) — Amendment now appears in both the Certificate and Exemption Order category pages
- On submit, document_category_id is resolved from restrictToCategoryId (category page) or the type's first category (standalone manual entry)

**Condition Loader**

- Both loadConditions.py and loaders/document_loader.py updated to include document_category_id in document inserts, using a mapping from document type name to category ID