### PR TITLE
CR-85:Condition Description and Condition Attribute tab changes

### DIFF
--- a/condition-web/src/components/ConditionDetails/ConditionInfoTabs.tsx
+++ b/condition-web/src/components/ConditionDetails/ConditionInfoTabs.tsx
@@ -12,31 +12,30 @@ import { useHasAllowedRoles, KeycloakRoles } from "@/hooks/useAuthorization";
 const StyledTabs = styled(Tabs)({
     transition: 'none',
     minHeight: 0,
-    borderBottom: `1px solid ${BCDesignTokens.surfaceColorBorderDefault}`
+    '& .MuiTabs-indicator': {
+        display: 'none',
+    },
 });
 
 const StyledTab = styled(Tab)(({ theme }) => ({
     height: '31px',
     minHeight: 0,
-    color: theme.palette.secondary.main,
-    fontWeight: 'inherit',
+    color: theme.palette.text.primary,
+    fontWeight: 400,
     backgroundColor: '#EDEBE9',
     marginRight: '4px',
     borderTopLeftRadius: '4px',
     borderTopRightRadius: '4px',
-    border: '1px solid transparent',
-    borderBottom: 'none',
+    border: '1px solid #D6D6D6',
 
     '&.Mui-selected': {
-        color: theme.palette.primary.contrastText,
-        backgroundColor: theme.palette.primary.main,
-        border: `1px solid ${theme.palette.primary.main}`,
+        color: '#313132',
+        backgroundColor: '#FFFFFF',
+        borderTop: '1px solid #D6D6D6',
+        borderLeft: '1px solid #D6D6D6',
+        borderRight: '1px solid #D6D6D6',
         borderBottom: 'none',
         fontWeight: 700,
-    },
-
-    '&:not(.Mui-selected)': {
-        color: BCDesignTokens.surfaceColorBorderDark,
     },
 }));
 
@@ -82,10 +81,8 @@ const ConditionInfoTabs: React.FC<{
         <>
             <Stack
                 direction="row"
-                alignItems="center"
-                sx={{
-                    borderBottom: `1px solid ${BCDesignTokens.surfaceColorBorderDefault}`
-                }}
+                alignItems="flex-end"
+                sx={{ position: 'relative', zIndex: 1 }}
             >
                 <StyledTabs value={selectedTab} onChange={handleTabChange} aria-label="Condition details tabs">
                     <StyledTab label="Condition Requirements" value="requirements" />
@@ -142,25 +139,27 @@ const ConditionInfoTabs: React.FC<{
                     </EditButton>
                 )}
             </Stack>
-            <Box sx={{ p: 2 }}>
-                <Box sx={{ display: selectedTab === 'requirements' ? 'block' : 'none' }}>
-                    <ConditionDescription
-                        editMode={editMode}
-                        projectId={projectId}
-                        documentId={documentId}
-                        conditionId={conditionId}
-                        condition={condition}
-                        isConditionApproved={isConditionApproved}
-                        setIsConditionApproved={setIsConditionApproved}
-                        setCondition={setCondition}
-                        setIsLoading={setIsLoading}
-                    />
-                </Box>
-                <Box sx={{ display: selectedTab === 'attributes' ? 'block' : 'none' }}>
-                    <ConditionAttribute
-                        condition={condition}
-                        setCondition={setCondition}
-                    />
+            <Box sx={{ border: '1px solid #D6D6D6', borderRadius: '0 4px 4px 4px', mt: '-1px', position: 'relative', zIndex: 0 }}>
+                <Box sx={{ border: `1px solid ${BCDesignTokens.surfaceColorBorderDefault}`, borderRadius: '4px', m: '15px 18px 25px 18px', p: 2 }}>
+                    <Box sx={{ display: selectedTab === 'requirements' ? 'block' : 'none' }}>
+                        <ConditionDescription
+                            editMode={editMode}
+                            projectId={projectId}
+                            documentId={documentId}
+                            conditionId={conditionId}
+                            condition={condition}
+                            isConditionApproved={isConditionApproved}
+                            setIsConditionApproved={setIsConditionApproved}
+                            setCondition={setCondition}
+                            setIsLoading={setIsLoading}
+                        />
+                    </Box>
+                    <Box sx={{ display: selectedTab === 'attributes' ? 'block' : 'none' }}>
+                        <ConditionAttribute
+                            condition={condition}
+                            setCondition={setCondition}
+                        />
+                    </Box>
                 </Box>
             </Box>
         </>

--- a/condition-web/src/components/ConditionDetails/CreateCondition/CreateConditionInfoTabs.tsx
+++ b/condition-web/src/components/ConditionDetails/CreateCondition/CreateConditionInfoTabs.tsx
@@ -19,31 +19,30 @@ import {
 const StyledTabs = styled(Tabs)({
     transition: 'none',
     minHeight: 0,
-    borderBottom: `1px solid ${BCDesignTokens.surfaceColorBorderDefault}`
+    '& .MuiTabs-indicator': {
+        display: 'none',
+    },
 });
 
 const StyledTab = styled(Tab)(({ theme }) => ({
     height: '31px',
     minHeight: 0,
-    color: theme.palette.secondary.main,
-    fontWeight: 'inherit',
+    color: theme.palette.text.primary,
+    fontWeight: 400,
     backgroundColor: '#EDEBE9',
     marginRight: '4px',
     borderTopLeftRadius: '4px',
     borderTopRightRadius: '4px',
-    border: '1px solid transparent',
-    borderBottom: 'none',
+    border: '1px solid #D6D6D6',
 
     '&.Mui-selected': {
-        color: theme.palette.primary.contrastText,
-        backgroundColor: theme.palette.primary.main,
-        border: `1px solid ${theme.palette.primary.main}`,
+        color: '#313132',
+        backgroundColor: '#FFFFFF',
+        borderTop: '1px solid #D6D6D6',
+        borderLeft: '1px solid #D6D6D6',
+        borderRight: '1px solid #D6D6D6',
         borderBottom: 'none',
         fontWeight: 700,
-    },
-
-    '&:not(.Mui-selected)': {
-        color: BCDesignTokens.surfaceColorBorderDark,
     },
 }));
 
@@ -119,9 +118,7 @@ const CreateConditionInfoTabs: React.FC<{
             <Stack
                 direction="row"
                 alignItems="center"
-                sx={{
-                    borderBottom: `1px solid ${BCDesignTokens.surfaceColorBorderDefault}`
-                }}
+                sx={{ position: 'relative', zIndex: 1 }}
             >
                 <StyledTabs value={selectedTab} onChange={handleTabChange} aria-label="Condition details tabs">
                     <StyledTab label="Condition Requirements" value="requirements" />
@@ -129,7 +126,8 @@ const CreateConditionInfoTabs: React.FC<{
                 </StyledTabs>
 
             </Stack>
-            <Box sx={{ p: 2 }}>
+            <Box sx={{ border: '1px solid #D6D6D6', borderRadius: '0 4px 4px 4px', mt: '-1px', position: 'relative', zIndex: 0 }}>
+                <Box sx={{ border: `1px solid ${BCDesignTokens.surfaceColorBorderDefault}`, borderRadius: '4px', m: '15px 18px 25px 18px', p: 2 }}>
                 <Box sx={{ display: selectedTab === 'requirements' ? 'block' : 'none' }}>
                     <DragDropContext onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
                         <Droppable
@@ -194,6 +192,7 @@ const CreateConditionInfoTabs: React.FC<{
                             setCondition={setCondition}
                         />
                     )}
+                </Box>
                 </Box>
             </Box>
         </>


### PR DESCRIPTION
### Summary

Replaced the flat MUI tab style on the Condition Details page with a folder/file-card pattern:

**Changes**
Inactive tabs: gray (#EDEBE9) background with full border and rounded top corners
Active tab: white background, bold label, 3-sided border (no bottom), visually connected to the content area below