### PR TITLE
CR-203:Adding Amendments to an Exemption Order from the Project page

### DIFF
--- a/condition-web/src/components/Projects/Project.tsx
+++ b/condition-web/src/components/Projects/Project.tsx
@@ -25,7 +25,9 @@ export const Project = ({ project }: ProjectParam) => {
     const navigate = useNavigate();
 
     const certificateDocument = project?.documents?.find(
-        (doc) => doc.document_category === "Certificate and Amendments"
+        (doc) =>
+            String(doc.document_category_id) === DocumentCategory.CertificateAndAmendments ||
+            String(doc.document_category_id) === DocumentCategory.ExemptionOrderAndAmendments
     );
 
     // Check if all documents have a status of true excluding other orders

--- a/condition-web/src/utils/enums.ts
+++ b/condition-web/src/utils/enums.ts
@@ -6,5 +6,7 @@ export enum DocumentTypes {
 }
 
 export enum DocumentCategory {
+    CertificateAndAmendments = '1',
+    ExemptionOrderAndAmendments = '2',
     OtherOrders = '3'
 }


### PR DESCRIPTION
**Summary**

- The "View Consolidated Conditions" button was permanently disabled for projects whose primary document category is "Exemption Order and Amendments"
- Added CertificateAndAmendments and ExemptionOrderAndAmendments values to the DocumentCategory enum
- Updated the certificateDocument check in Project.tsx to match on category ID for both certificate and exemption order categories, instead of hard-coding the "Certificate and Amendments" string