### PR TITLE
CR-203:Adding Amendments to an Exemption Order from the Project page

### DIFF
--- a/condition-api/migrations/versions/b1c2d3e4f5a6_add_document_category_id_to_extraction_requests.py
+++ b/condition-api/migrations/versions/b1c2d3e4f5a6_add_document_category_id_to_extraction_requests.py
@@ -1,0 +1,36 @@
+"""add_document_category_id_to_extraction_requests
+
+Revision ID: b1c2d3e4f5a6
+Revises: a1b2c3d4e5f6
+Create Date: 2026-07-16
+
+Add document_category_id to extraction_requests so the frontend-supplied
+category is stored with the request and used during import/manual entry
+instead of being derived server-side.
+"""
+from alembic import op
+
+revision = 'b1c2d3e4f5a6'
+down_revision = 'a1b2c3d4e5f6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""
+        ALTER TABLE condition.extraction_requests
+        ADD COLUMN IF NOT EXISTS document_category_id INTEGER
+            REFERENCES condition.document_categories(id) ON DELETE RESTRICT;
+    """)
+
+    op.execute("""
+        GRANT SELECT, INSERT, UPDATE, DELETE
+        ON condition.extraction_requests TO condition;
+    """)
+
+
+def downgrade():
+    op.execute("""
+        ALTER TABLE condition.extraction_requests
+        DROP COLUMN IF EXISTS document_category_id;
+    """)

--- a/condition-api/src/condition_api/models/extraction_request.py
+++ b/condition-api/src/condition_api/models/extraction_request.py
@@ -18,6 +18,7 @@ class ExtractionRequest(BaseModel):
     project_id = Column(String(255), ForeignKey('condition.projects.project_id'), nullable=False)
     document_id = Column(String(255), nullable=True)
     document_type_id = Column(Integer, ForeignKey('condition.document_types.id'), nullable=True)
+    document_category_id = Column(Integer, ForeignKey('condition.document_categories.id'), nullable=True)
     uploaded_by_staff_user_id = Column(Integer, ForeignKey('condition.staff_users.id'), nullable=True)
     imported_by_staff_user_id = Column(Integer, ForeignKey('condition.staff_users.id'), nullable=True)
     document_label = Column(Text, nullable=True)

--- a/condition-api/src/condition_api/schemas/extraction_request.py
+++ b/condition-api/src/condition_api/schemas/extraction_request.py
@@ -9,6 +9,7 @@ class ExtractionRequestSchema(Schema):
     project_id = fields.Str(required=True)
     document_id = fields.Str(allow_none=True)
     document_type_id = fields.Int(allow_none=True)
+    document_category_id = fields.Int(allow_none=True)
     document_label = fields.Str(allow_none=True)
     date_issued = fields.Str(allow_none=True)
     act = fields.Int(allow_none=True)

--- a/condition-api/src/condition_api/services/extraction_request_service.py
+++ b/condition-api/src/condition_api/services/extraction_request_service.py
@@ -1,7 +1,6 @@
 """Service for extraction request management."""
 import logging
 from datetime import datetime
-from typing import Optional
 
 from flask import current_app
 from sqlalchemy.exc import SQLAlchemyError
@@ -9,7 +8,6 @@ from sqlalchemy.orm import selectinload
 
 from condition_api.models.db import db
 from condition_api.models.document import Document
-from condition_api.models.document_type_category import DocumentTypeCategory
 from condition_api.models.extraction_request import ExtractionRequest
 from condition_api.models.project import Project
 from condition_api.services.extraction_import_service import load_extracted_data
@@ -33,19 +31,6 @@ class ExtractionRequestService:
         return None
 
     @staticmethod
-    def _resolve_document_category_id(document_type_id: Optional[int]) -> Optional[int]:
-        """Return the single category for a document type via the junction table."""
-        if not document_type_id:
-            return None
-        row = (
-            db.session.query(DocumentTypeCategory)
-            .filter_by(document_type_id=document_type_id)
-            .order_by(DocumentTypeCategory.id)
-            .first()
-        )
-        return row.document_category_id if row else None
-
-    @staticmethod
     def create(data: dict) -> ExtractionRequest:
         """Create a new extraction request with status pending.
 
@@ -58,6 +43,7 @@ class ExtractionRequestService:
             project_id=data['project_id'],
             document_id=data.get('document_id'),
             document_type_id=data.get('document_type_id'),
+            document_category_id=data.get('document_category_id'),
             uploaded_by_staff_user_id=current_staff_user.id if current_staff_user else None,
             document_label=data.get('document_label'),
             original_file_name=data.get('original_file_name'),
@@ -93,10 +79,6 @@ class ExtractionRequestService:
                 db.session.add(document)
                 logger.info("Created new document document_id=%s from extraction request", document_id)
             else:
-                # Always honour the document type the user explicitly selected, even
-                # when the document already exists in the DB with a different type.
-                # Also clear any stale document_category_id so import picks up the
-                # correct category for the new type.
                 if data.get('document_type_id'):
                     document.document_type_id = data['document_type_id']
 
@@ -187,9 +169,7 @@ class ExtractionRequestService:
                 if document:
                     if req.document_type_id:
                         document.document_type_id = req.document_type_id
-                        document.document_category_id = (
-                            ExtractionRequestService._resolve_document_category_id(req.document_type_id)
-                        )
+                        document.document_category_id = req.document_category_id
                     document.is_active = True
 
             project = db.session.query(Project).filter_by(project_id=req.project_id).first()
@@ -277,9 +257,7 @@ class ExtractionRequestService:
                 if document:
                     if req.document_type_id:
                         document.document_type_id = req.document_type_id
-                        document.document_category_id = (
-                            ExtractionRequestService._resolve_document_category_id(req.document_type_id)
-                        )
+                        document.document_category_id = req.document_category_id
                     document.is_active = True
 
             # Activate the project now that extraction is complete and imported.

--- a/condition-web/src/components/ConditionDetails/ConditionAttribute/Independent/ConditionAttributeTable.tsx
+++ b/condition-web/src/components/ConditionDetails/ConditionAttribute/Independent/ConditionAttributeTable.tsx
@@ -66,6 +66,9 @@ const ConditionAttributeTable = memo(({
       queryClient.invalidateQueries({
         queryKey: [QUERY_KEY.CONDITIONSDETAIL],
       });
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEY.ATTRIBUTEKEYS, condition.condition_id],
+      });
     };
   
     const { data: conditionAttributeDetails, mutateAsync: updateAttributes } = useUpdateConditionAttributeDetails(
@@ -83,6 +86,7 @@ const ConditionAttributeTable = memo(({
           notify.success("Attribute deleted successfully");
           queryClient.invalidateQueries({ queryKey: ["conditions", condition.condition_id] });
           queryClient.invalidateQueries({ queryKey: [QUERY_KEY.CONDITIONSDETAIL] });
+          queryClient.invalidateQueries({ queryKey: [QUERY_KEY.ATTRIBUTEKEYS, condition.condition_id] });
         },
         onError: () => notify.error("Failed to delete attribute"),
       }


### PR DESCRIPTION
Summary

- Store document_category_id on the extraction request — added the column to extraction_requests via migration, model, and schema so the frontend-supplied category travels with the request rather than being derived server-side at import time
- Simplified import/manual-entry flow — replaced the _resolve_document_category_id helper (which looked up category via the DocumentTypeCategory junction table) with a direct read of req.document_category_id, removing a DB lookup and the coupling to the junction table
