### PR TITLE
CR-204:Condition Attributes: Radio buttons disabled after clicking delete/trash icon

### DIFF
--- a/condition-web/src/components/ConditionDetails/ConditionAttribute/ManagementPlan/ManagementPlanSection.tsx
+++ b/condition-web/src/components/ConditionDetails/ConditionAttribute/ManagementPlan/ManagementPlanSection.tsx
@@ -15,6 +15,7 @@ import { notify } from "@/components/Shared/Snackbar/snackbarStore";
 import { useQueryClient } from "@tanstack/react-query";
 import { QUERY_KEY } from "@/hooks/api/constants";
 import { useHasAllowedRoles, KeycloakRoles } from "@/hooks/useAuthorization";
+import { useUpdateConditionDetails } from "@/hooks/api/useConditions";
 
 type ManagementPlanSectionProps = {
     condition: ConditionModel;
@@ -54,6 +55,12 @@ const ManagementPlanSection = memo(({ condition, setCondition, }: ManagementPlan
       },
     });
 
+    const { mutate: updateConditionDetails } = useUpdateConditionDetails(
+      false,
+      false,
+      condition.condition_id
+    );
+
     const handleAddPlan = async () => {
       const newPlan: ManagementPlanModel = createDefaultManagementPlan(
         `(condition.condition_attributes?.length || 0) + 1-${Date.now()}`,
@@ -91,14 +98,22 @@ const ManagementPlanSection = memo(({ condition, setCondition, }: ManagementPlan
 
     const handleDeletePlan = async (planId: string) => {
       await removeManagementPlan(planId);
-      setCondition((prev) => ({
-        ...prev,
-        condition_attributes: {
-          ...prev.condition_attributes,
-          management_plans: prev.condition_attributes?.management_plans?.filter(p => p.id !== planId) || [],
-          independent_attributes: prev.condition_attributes?.independent_attributes || [],
-        },
-      }));
+      setCondition((prev) => {
+        const remainingPlans = prev.condition_attributes?.management_plans?.filter(p => p.id !== planId) || [];
+        const allApproved = remainingPlans.length > 0 && remainingPlans.every(p => p.is_approved);
+        if (prev.is_condition_attributes_approved !== allApproved) {
+          updateConditionDetails({ is_condition_attributes_approved: allApproved });
+        }
+        return {
+          ...prev,
+          is_condition_attributes_approved: allApproved,
+          condition_attributes: {
+            ...prev.condition_attributes,
+            management_plans: remainingPlans,
+            independent_attributes: prev.condition_attributes?.independent_attributes || [],
+          },
+        };
+      });
     };
 
     return (

--- a/condition-web/src/components/ConditionDetails/ConditionAttribute/index.tsx
+++ b/condition-web/src/components/ConditionDetails/ConditionAttribute/index.tsx
@@ -176,18 +176,28 @@ const ConditionAttribute = memo(({
                             }
                         }}
                     >
-                        <FormControlLabel
-                            value="true"
-                            control={<Radio />}
-                            label="Yes"
-                            disabled={!canManage || (condition?.is_condition_attributes_approved || false)}
-                        />
-                        <FormControlLabel
-                            value="false"
-                            control={<Radio />}
-                            label="No"
-                            disabled={!canManage || (condition?.is_condition_attributes_approved || false)}
-                        />
+                        {(() => {
+                            const plans = condition?.condition_attributes?.management_plans || [];
+                            const isDisabled = !canManage
+                                || (condition?.is_condition_attributes_approved || false)
+                                || (plans.length > 1 && plans.some(p => p.is_approved));
+                            return (
+                                <>
+                                    <FormControlLabel
+                                        value="true"
+                                        control={<Radio />}
+                                        label="Yes"
+                                        disabled={isDisabled}
+                                    />
+                                    <FormControlLabel
+                                        value="false"
+                                        control={<Radio />}
+                                        label="No"
+                                        disabled={isDisabled}
+                                    />
+                                </>
+                            );
+                        })()}
                     </RadioGroup>
                 </FormControl>
 


### PR DESCRIPTION
Fix: Radio buttons re-enable correctly after management plan deletion and confirmation
- Fixed a bug where the "Does this condition require one or more Management Plan(s)?" radio buttons remained disabled after deleting a confirmed management plan — both in local state and on the backend (page refresh).
- Added a new disable rule: radio buttons are also locked when multiple management plans exist and any one of them is confirmed, preventing accidental data loss.