### PR TITLE
CR-209:Unable to Edit Extracted Conditions

### DIFF
--- a/condition-web/src/components/ConditionDetails/ConditionDescription.tsx
+++ b/condition-web/src/components/ConditionDetails/ConditionDescription.tsx
@@ -37,6 +37,13 @@ type ConditionDescriptionProps = {
   setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
+const normalizeSubconditions = (subs: SubconditionModel[]): SubconditionModel[] =>
+  subs.map((sub) => ({
+    ...sub,
+    subcondition_identifier: sub.subcondition_identifier ?? "",
+    subconditions: normalizeSubconditions(sub.subconditions || []),
+  }));
+
 // Main component to render the condition and its subconditions
 const ConditionDescription = memo(({
   editMode,
@@ -84,13 +91,6 @@ const ConditionDescription = memo(({
       onError: onCreateFailure,
     }
   );
-
-  const normalizeSubconditions = (subs: SubconditionModel[]): SubconditionModel[] =>
-    subs.map((sub) => ({
-      ...sub,
-      subcondition_identifier: sub.subcondition_identifier ?? "",
-      subconditions: normalizeSubconditions(sub.subconditions || []),
-    }));
 
   const saveChanges = useCallback(() => {
     const data: updateTopicTagsModel = {

--- a/condition-web/src/components/ConditionDetails/ConditionDescription.tsx
+++ b/condition-web/src/components/ConditionDetails/ConditionDescription.tsx
@@ -2,6 +2,7 @@ import { memo, useEffect, useState, useCallback, useRef } from 'react';
 import { Box, Typography, Button, Stack } from "@mui/material";
 import AddIcon from '@mui/icons-material/Add';
 import { ConditionModel } from "@/models/Condition";
+import { SubconditionModel } from "@/models/Subcondition";
 import { theme } from "@/styles/theme";
 import { useUpdateConditionDetails } from "@/hooks/api/useConditions";
 import { notify } from "@/components/Shared/Snackbar/snackbarStore";
@@ -84,9 +85,16 @@ const ConditionDescription = memo(({
     }
   );
 
+  const normalizeSubconditions = (subs: SubconditionModel[]): SubconditionModel[] =>
+    subs.map((sub) => ({
+      ...sub,
+      subcondition_identifier: sub.subcondition_identifier ?? "",
+      subconditions: normalizeSubconditions(sub.subconditions || []),
+    }));
+
   const saveChanges = useCallback(() => {
     const data: updateTopicTagsModel = {
-      subconditions: subconditions
+      subconditions: normalizeSubconditions(subconditions)
     };
     updateConditionDetails(data);
   }, [subconditions, updateConditionDetails]);


### PR DESCRIPTION
Summary
- When subconditions are loaded from the API, some may have subcondition_identifier: null stored in the database (e.g. text-only subconditions with no letter/number prefix)
- Rearranging subconditions triggers a save of the full subcondition list, which passed null identifiers directly to the API
- The backend marshmallow schema rejects null for subcondition_identifier, causing a 500 error on PATCH /api/conditions/{id}/edit
- Added normalizeSubconditions in ConditionDescription.tsx to coerce null → "" recursively before the payload is sent
