### PR TITLE
CR-211:Allow for Amendments to be added from bucket 'Other Orders'

### DIFF
--- a/condition-api/migrations/versions/c2d3e4f5a6b7_allow_amendment_in_other_orders_category.py
+++ b/condition-api/migrations/versions/c2d3e4f5a6b7_allow_amendment_in_other_orders_category.py
@@ -1,0 +1,32 @@
+"""allow_amendment_in_other_orders_category
+
+Revision ID: c2d3e4f5a6b7
+Revises: b1c2d3e4f5a6
+Create Date: 2026-08-04
+
+Allow Amendment (type 3) to be created under the Other Orders category (id 3)
+by adding the missing row to document_type_categories.
+"""
+from alembic import op
+
+revision = 'c2d3e4f5a6b7'
+down_revision = 'b1c2d3e4f5a6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""
+        INSERT INTO condition.document_type_categories
+            (document_type_id, document_category_id, created_date, updated_date)
+        VALUES
+            (3, 3, NOW(), NOW())   -- Amendment → Other Orders
+        ON CONFLICT (document_type_id, document_category_id) DO NOTHING;
+    """)
+
+
+def downgrade():
+    op.execute("""
+        DELETE FROM condition.document_type_categories
+        WHERE document_type_id = 3 AND document_category_id = 3;
+    """)

--- a/condition-web/src/components/Conditions/CreateConditionModal.tsx
+++ b/condition-web/src/components/Conditions/CreateConditionModal.tsx
@@ -23,7 +23,7 @@ import { ConditionModel, ConditionType } from "@/models/Condition";
 import { notify } from "@/components/Shared/Snackbar/snackbarStore";
 import { useNavigate } from "@tanstack/react-router";
 import { HTTP_STATUS_CODES } from "../../hooks/api/constants";
-import { DocumentTypes } from "@/utils/enums"
+import { DocumentTypes } from "@/utils/enums";
 
 type ConditionModalProps = {
   open: boolean;

--- a/condition-web/src/components/Projects/Project.tsx
+++ b/condition-web/src/components/Projects/Project.tsx
@@ -26,18 +26,22 @@ export const Project = ({ project }: ProjectParam) => {
 
     const certificateDocument = project?.documents?.find(
         (doc) =>
-            String(doc.document_category_id) === DocumentCategory.CertificateAndAmendments ||
-            String(doc.document_category_id) === DocumentCategory.ExemptionOrderAndAmendments
+            (String(doc.document_category_id) === DocumentCategory.CertificateAndAmendments ||
+            String(doc.document_category_id) === DocumentCategory.ExemptionOrderAndAmendments) &&
+            doc.is_latest_amendment_added === true
     );
 
-    // Check if all documents have a status of true excluding other orders
-    const allDocumentsStatusTrue = project?.documents?.every(doc => 
-        String(doc.document_category_id) === DocumentCategory.OtherOrders 
-        || (doc.is_latest_amendment_added === true && doc.status !== null)
+    const otherOrderWithAmendments = project?.documents?.find(
+        (doc) =>
+            String(doc.document_category_id) === DocumentCategory.OtherOrders &&
+            doc.amendment_count > 0 &&
+            doc.is_latest_amendment_added === true
     );
+
+    const canViewConsolidated = !!(certificateDocument || otherOrderWithAmendments);
 
     const handleViewConsolidatedConditions = () => {
-        if (project?.project_id && certificateDocument) {
+        if (project?.project_id && canViewConsolidated) {
             navigate({
                 to: `/projects/${project?.project_id}/consolidated-conditions`,
             });
@@ -76,7 +80,7 @@ export const Project = ({ project }: ProjectParam) => {
                     variant="contained"
                     color="secondary"
                     onClick={handleViewConsolidatedConditions}
-                    disabled={!project || !certificateDocument || !allDocumentsStatusTrue}
+                    disabled={!project || !canViewConsolidated}
                     sx={{
                         color: BCDesignTokens.themeGray100,
                         border: `2px solid ${theme.palette.grey[700]}`,


### PR DESCRIPTION
Allow Amendments on Other Orders & Enable Consolidated Conditions Button

Changes:
- Added a new migration to allow Amendment as a valid document type under the Other Orders category (document_type_categories), enabling users to select "Amendment" when adding a document from the Other Orders page.
- Updated the View Consolidated Conditions button logic in Project.tsx:
- Now enables for Certificate / Exemption Order documents where is_latest_amendment_added = true
- Also enables for Other Orders that have at least one amendment (amendment_count > 0) and is_latest_amendment_added = true
- Replaced the previous allDocumentsStatusTrue check (which required every document across the project to be complete) with per-category checks, making the logic more explicit and predictable