### PR TITLE
CR-211:Allow for Amendments to be added from bucket 'Other Orders'

### DIFF
--- a/condition-api/src/condition_api/resources/document.py
+++ b/condition-api/src/condition_api/resources/document.py
@@ -77,7 +77,10 @@ class DocumentsResource(Resource):
         try:
             document_id = request.args.get("documentId")
             document_type = request.args.get("documentType")
-            documents = DocumentService.get_all_documents_by_project_id(project_id, document_id, document_type)
+            document_category_id = request.args.get("documentCategoryId")
+            documents = DocumentService.get_all_documents_by_project_id(
+                project_id, document_id, document_type, document_category_id
+            )
             if not documents:
                 return {}
 

--- a/condition-api/src/condition_api/services/document_service.py
+++ b/condition-api/src/condition_api/services/document_service.py
@@ -255,7 +255,7 @@ class DocumentService:
         return existing_document
 
     @staticmethod
-    def get_all_documents_by_project_id(project_id, document_id=None, document_type=None):
+    def get_all_documents_by_project_id(project_id, document_id=None, document_type=None, document_category_id=None):
         """Fetch all documents and its amendments for the given project_id."""
         documents_query = db.session.query(
             Document.id.label('document_record_id'),
@@ -269,6 +269,11 @@ class DocumentService:
             Project.project_id == project_id,
             Document.is_active.is_(True)
         )
+
+        if document_category_id is not None:
+            documents_query = documents_query.filter(
+                Document.document_category_id == int(document_category_id)
+            )
 
         documents = documents_query.all()
 

--- a/condition-web/src/components/Documents/DocumentEntryForm.tsx
+++ b/condition-web/src/components/Documents/DocumentEntryForm.tsx
@@ -148,7 +148,8 @@ export const DocumentEntryForm = ({
         formState.selectedDocumentType === DocumentTypes.Amendment,
         formState.selectedProject?.project_id,
         undefined,
-        DocumentTypes.Certificate.toString()
+        DocumentTypes.Certificate.toString(),
+        restrictToCategoryId
     );
 
     useEffect(() => {

--- a/condition-web/src/hooks/api/useDocuments.tsx
+++ b/condition-web/src/hooks/api/useDocuments.tsx
@@ -179,7 +179,7 @@ export const useUpdateDocumentDetails = (
   });
 };
 
-const fetchDocumentsByProject = (projectId?: string, documentId?: string, documentType?: string) => {
+const fetchDocumentsByProject = (projectId?: string, documentId?: string, documentType?: string, categoryId?: number | null) => {
   if (!projectId) {
     return Promise.reject(new Error("Project ID is required"));
   }
@@ -189,6 +189,7 @@ const fetchDocumentsByProject = (projectId?: string, documentId?: string, docume
     params: {
       documentId,
       documentType,
+      ...(categoryId != null ? { documentCategoryId: categoryId } : {}),
     },
   });
 
@@ -198,7 +199,8 @@ export const useGetDocumentsByProject = (
   shouldLoad: boolean,
   projectId?: string,
   documentId?: string,
-  documentType?: string
+  documentType?: string,
+  categoryId?: number | null
 ) => {
   return useQuery({
     queryKey: [
@@ -206,8 +208,9 @@ export const useGetDocumentsByProject = (
       projectId,
       documentId,
       documentType,
+      categoryId,
     ],
-    queryFn: () => fetchDocumentsByProject(projectId, documentId, documentType),
+    queryFn: () => fetchDocumentsByProject(projectId, documentId, documentType, categoryId),
     enabled: Boolean(projectId && shouldLoad),
     ...defaultUseQueryOptions,
   });


### PR DESCRIPTION
Allow Amendments on Other Orders & Fix Document Selection

Users can now add Amendment documents from the Other Orders category, matching the behaviour already available for Certificates and Exemption Orders.

When selecting a document to amend, the dropdown now only shows documents from the same package type the user is working in — previously it showed all project documents regardless of category, which was confusing.

The "View Consolidated Conditions" button is also enabled for Other Orders that have amendments, bringing it in line with the other document categories.