### PR TITLE
CR-211 1 Allow for Amendments to be added from bucket 'Other Order'

### DIFF
--- a/condition-web/src/components/Projects/Project.tsx
+++ b/condition-web/src/components/Projects/Project.tsx
@@ -38,7 +38,11 @@ export const Project = ({ project }: ProjectParam) => {
             doc.is_latest_amendment_added === true
     );
 
-    const canViewConsolidated = !!(certificateDocument || otherOrderWithAmendments);
+    const allDocumentsStatusTrue = project?.documents?.every(doc =>
+        doc.is_latest_amendment_added === true && doc.status !== null
+    );
+
+    const canViewConsolidated = !!(certificateDocument || otherOrderWithAmendments) && !!allDocumentsStatusTrue;
 
     const handleViewConsolidatedConditions = () => {
         if (project?.project_id && canViewConsolidated) {


### PR DESCRIPTION
The "View Consolidated Conditions" button is now enabled for Other Orders that have amendments, and is correctly blocked when any document in the project — including Other Orders — still has data entry pending.