### PR TITLE
CR-211:Allow for Amendments to be added from bucket 'Other Orders'

### DIFF
--- a/condition-web/src/components/Projects/Project.tsx
+++ b/condition-web/src/components/Projects/Project.tsx
@@ -5,7 +5,6 @@ import DocumentTable from "./DocumentTable";
 import { ContentBox } from "../Shared/ContentBox";
 import { useNavigate } from "@tanstack/react-router";
 import { theme } from "@/styles/theme";
-import { DocumentCategory } from "@/utils/enums"
 
 export const CardInnerBox = styled(Box)({
     display: "flex",
@@ -24,25 +23,16 @@ export const Project = ({ project }: ProjectParam) => {
 
     const navigate = useNavigate();
 
-    const certificateDocument = project?.documents?.find(
-        (doc) =>
-            (String(doc.document_category_id) === DocumentCategory.CertificateAndAmendments ||
-            String(doc.document_category_id) === DocumentCategory.ExemptionOrderAndAmendments) &&
-            doc.is_latest_amendment_added === true
-    );
-
-    const otherOrderWithAmendments = project?.documents?.find(
-        (doc) =>
-            String(doc.document_category_id) === DocumentCategory.OtherOrders &&
-            doc.amendment_count > 0 &&
-            doc.is_latest_amendment_added === true
-    );
-
-    const allDocumentsStatusTrue = project?.documents?.every(doc =>
+    const hasAtLeastOneLatest = project?.documents?.some(doc =>
         doc.is_latest_amendment_added === true && doc.status !== null
     );
 
-    const canViewConsolidated = !!(certificateDocument || otherOrderWithAmendments) && !!allDocumentsStatusTrue;
+    const allDocumentsStatusTrue = project?.documents?.every(doc =>
+        doc.amendment_count === 0
+        || (doc.is_latest_amendment_added === true && doc.status !== null)
+    );
+
+    const canViewConsolidated = !!hasAtLeastOneLatest && !!allDocumentsStatusTrue;
 
     const handleViewConsolidatedConditions = () => {
         if (project?.project_id && canViewConsolidated) {

--- a/condition-web/src/components/Projects/Project.tsx
+++ b/condition-web/src/components/Projects/Project.tsx
@@ -23,18 +23,17 @@ export const Project = ({ project }: ProjectParam) => {
 
     const navigate = useNavigate();
 
-    const hasAtLeastOneLatest = project?.documents?.some(doc =>
-        doc.amendment_count > 0 &&
-        doc.is_latest_amendment_added === true &&
-        doc.status !== null
+    const anyDataEntryRequired = project?.documents?.some(doc => doc.status === null);
+
+    const totalDocumentCount = project?.documents?.reduce(
+        (sum, doc) => sum + 1 + (doc.amendment_count || 0), 0
+    ) ?? 0;
+
+    const anyMissingMostRecent = project?.documents?.some(doc =>
+        doc.amendment_count > 0 && doc.is_latest_amendment_added !== true
     );
 
-    const allDocumentsStatusTrue = project?.documents?.every(doc =>
-        doc.amendment_count === 0
-        || (doc.is_latest_amendment_added === true && doc.status !== null)
-    );
-
-    const canViewConsolidated = !!hasAtLeastOneLatest && !!allDocumentsStatusTrue;
+    const canViewConsolidated = !anyDataEntryRequired && totalDocumentCount > 1 && !anyMissingMostRecent;
 
     const handleViewConsolidatedConditions = () => {
         if (project?.project_id && canViewConsolidated) {

--- a/condition-web/src/components/Projects/Project.tsx
+++ b/condition-web/src/components/Projects/Project.tsx
@@ -24,7 +24,9 @@ export const Project = ({ project }: ProjectParam) => {
     const navigate = useNavigate();
 
     const hasAtLeastOneLatest = project?.documents?.some(doc =>
-        doc.is_latest_amendment_added === true && doc.status !== null
+        doc.amendment_count > 0 &&
+        doc.is_latest_amendment_added === true &&
+        doc.status !== null
     );
 
     const allDocumentsStatusTrue = project?.documents?.every(doc =>


### PR DESCRIPTION
"View Consolidated Conditions" button is enabled only when:

- At least one document in the project has an amendment marked as the latest and data entry is complete
- No document in the project has an amendment that is not marked as the latest
- Documents with no amendments are ignored and do not affect the button

The button remains disabled when:

- A document only has a single Certificate or Exemption Order with no amendments (consolidated view would be redundant)
- Any document has an amendment not marked as the latest (consolidated view would be incomplete)
- Any document still has data entry pending