### PR TITLE
Add structured report extraction to condition-cron extraction pipeline

### DIFF
--- a/condition-api/src/condition_api/services/extraction_import_service.py
+++ b/condition-api/src/condition_api/services/extraction_import_service.py
@@ -17,9 +17,7 @@ from condition_api.utils.enums import ConditionType
 
 ATTRIBUTE_EXTERNAL_KEYS = (
     "approval_type",
-    "days_prior_to_commencement",
     "related_phase",
-    "deliverable_name",
     "management_plan_acronym",
     "fn_consultation_required",
     "implementation_phase",
@@ -29,12 +27,17 @@ ATTRIBUTE_EXTERNAL_KEYS = (
 
 ATTRIBUTE_EXTERNAL_KEY_ALIASES = {
     "approval_type": "submitted_to_eao_for",
-    "days_prior_to_commencement": "time_associated_with_submission_milestone",
+    "related_phase": "milestone_related_to_plan_submission",
     "implementation_phase": "milestones_related_to_plan_implementation",
     "fn_consultation_required": "requires_consultation",
     "stakeholders_to_submit_to": "parties_required_to_be_submitted",
     "stakeholders_to_consult": "parties_required_to_be_consulted",
 }
+
+# Combines submission_time_value/unit/direction into the single free-text value
+# expected by condition-web's "Time associated with submission milestone" field,
+# e.g. "60 Days Before" — see DynamicFieldRenderer.tsx's parsing regex.
+SUBMISSION_TIME_EXTERNAL_KEY = "time_associated_with_submission_milestone"
 
 
 class ExtractionImportService:
@@ -172,6 +175,17 @@ class ExtractionImportService:
                 )
                 db.session.add(attribute)
 
+            submission_time_value = self._format_submission_time(deliverable)
+            if submission_time_value is not None:
+                attribute_key = self.attribute_keys.get(SUBMISSION_TIME_EXTERNAL_KEY)
+                if attribute_key:
+                    db.session.add(ConditionAttribute(
+                        condition_id=condition.id,
+                        attribute_key_id=attribute_key.id,
+                        attribute_value=submission_time_value,
+                        management_plan_id=management_plan.id if management_plan else None,
+                    ))
+
     @staticmethod
     def _list_or_none(value: Any) -> list[Any] | None:
         if value is None:
@@ -179,6 +193,20 @@ class ExtractionImportService:
         if isinstance(value, list):
             return value
         return [value]
+
+    @staticmethod
+    def _format_submission_time(deliverable: dict[str, Any]) -> str | None:
+        """Combine submission_time_value/unit/direction into e.g. '60 Days Before'.
+
+        Matches the "{value} {Days|Month(s)|Year(s)} {After|Before|Prior to}"
+        format that condition-web's DynamicFieldRenderer parses back apart.
+        """
+        value = deliverable.get("submission_time_value")
+        unit = deliverable.get("submission_time_unit")
+        direction = deliverable.get("submission_time_direction")
+        if value is None or not unit or not direction:
+            return None
+        return f"{value} {unit} {direction}"
 
     @staticmethod
     def _serialize_attribute_value(value: Any) -> str | None:

--- a/condition-api/tests/unit/apis/model/test_project.py
+++ b/condition-api/tests/unit/apis/model/test_project.py
@@ -35,7 +35,7 @@ def test_get_all_projects_endpoint(client, session, auth_header):
     project = factory_project_model(project_id="58851056aaecd9001b80ebf8")
     category = get_seeded_document_category("Certificate and Amendments")
     doc_type = get_seeded_document_type("Certificate")
-    document = factory_document_model(project.project_id, doc_type.id)
+    document = factory_document_model(project.project_id, doc_type.id, document_category_id=category.id)
 
     # Pass both document_id and project_id to avoid IntegrityError
     factory_condition_model(document.document_id, project.project_id)

--- a/condition-api/tests/unit/apis/resources/test_condition_resource.py
+++ b/condition-api/tests/unit/apis/resources/test_condition_resource.py
@@ -20,6 +20,7 @@ from tests.utilities.factory_utils import (
     factory_project_model,
     factory_user_model,
     factory_document_model,
+    get_seeded_document_category,
     get_seeded_document_type,
     factory_auth_header
 )
@@ -42,8 +43,10 @@ def setup_condition(session):
     """Create a project, document and condition for testing."""
     project = factory_project_model(project_id=str(uuid.uuid4()))
     doc_type = get_seeded_document_type("Certificate")
+    category = get_seeded_document_category("Certificate and Amendments")
     document = factory_document_model(
-        project_id=project.project_id, document_type_id=doc_type.id
+        project_id=project.project_id, document_type_id=doc_type.id,
+        document_category_id=category.id
     )
     condition = factory_condition_model(
         project_id=project.project_id, document_id=document.document_id

--- a/condition-api/tests/unit/apis/resources/test_document_category_resource.py
+++ b/condition-api/tests/unit/apis/resources/test_document_category_resource.py
@@ -13,6 +13,7 @@ from tests.utilities.factory_utils import (
     factory_project_model,
     factory_user_model,
     factory_document_model,
+    get_seeded_document_category,
     get_seeded_document_type,
     factory_auth_header
 )
@@ -34,10 +35,14 @@ def test_get_documents_by_category_success(client, auth_user):
     """Test fetching documents by project and category successfully."""
     project = factory_project_model(project_id=str(uuid.uuid4()))
     doc_type = get_seeded_document_type("Certificate")
-    factory_document_model(project_id=project.project_id, document_type_id=doc_type.id)
+    category = get_seeded_document_category("Certificate and Amendments")
+    factory_document_model(
+        project_id=project.project_id, document_type_id=doc_type.id,
+        document_category_id=category.id
+    )
 
     response = client.get(
-        f"/api/document-category/project/{project.project_id}/category/{doc_type.id}",
+        f"/api/document-category/project/{project.project_id}/category/{category.id}",
         headers=auth_user
     )
 

--- a/condition-cron/src/condition_cron/extraction/extractor.py
+++ b/condition-cron/src/condition_cron/extraction/extractor.py
@@ -6,6 +6,7 @@ from condition_cron.extraction import pdf_reader
 from condition_cron.extraction.document_classifier import classify_document
 from condition_cron.extraction.pdf_reader import read_pdf_page_range, get_page_count
 from condition_cron.extraction.management_plans import extract_management_plan_info_from_json
+from condition_cron.extraction.reports import extract_report_info_from_json
 
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -337,9 +338,9 @@ def _deduplicate_conditions(conditions: List[Dict[str, Any]]) -> List[Dict[str, 
 # ---------------------------------------------------------------------------
 
 def enrich_condition(condition_text: str, condition_name: Optional[str] = None) -> Dict[str, Any]:
-    """Extract clauses, deliverables, and report submissions from a single condition.
+    """Break a single condition down into its nested clause/subcondition structure.
 
-    Returns a dict with: clauses, deliverables, report_submissions.
+    Returns a dict with: clauses.
     """
     enrichment_schema = load_schema("enrichment_schema")
 
@@ -351,11 +352,8 @@ def enrich_condition(condition_text: str, condition_name: Optional[str] = None) 
     prompt = (
         "Here is a condition from an environmental assessment document:\n\n"
         f"{full_text}\n\n"
-        "Extract the following from this condition:\n"
-        "1. Break it down into clauses and subconditions (nested structure with identifiers like 1.1, a), i., etc.)\n"
-        "2. Identify any deliverables — management plans, reports, proposals, or other documents that must be written/submitted\n"
-        "3. Identify any periodic report submission requirements (separate from one-time deliverables)\n"
-        "If any category has no items, return an empty array for that category."
+        "Break it down into clauses and subconditions (nested structure with identifiers like 1.1, a), i., etc.)\n"
+        "If it has no sub-structure, return an empty array."
     )
 
     messages = [{"role": "user", "content": prompt}]
@@ -376,11 +374,11 @@ def enrich_condition(condition_text: str, condition_name: Optional[str] = None) 
 
     except Exception as e:
         logger.error("Enrichment error: %s", e, exc_info=True)
-        return {"clauses": [], "deliverables": [], "report_submissions": []}
+        return {"clauses": []}
 
 
 def enrich_all_conditions(input_json: Dict[str, Any]) -> Dict[str, Any]:
-    """Enrich all conditions with clauses, deliverables, and report submissions.
+    """Enrich all conditions with their clause/subcondition structure.
 
     Modifies input_json in place and returns it.
     """
@@ -394,14 +392,8 @@ def enrich_all_conditions(input_json: Dict[str, Any]) -> Dict[str, Any]:
         enrichment = enrich_condition(condition_text, condition_name)
 
         condition["clauses"] = enrichment.get("clauses", [])
-        condition["deliverables"] = enrichment.get("deliverables", [])
-        condition["report_submissions"] = enrichment.get("report_submissions", [])
 
-        # Log what was found
-        n_clauses = len(condition["clauses"])
-        n_deliverables = len(condition["deliverables"])
-        n_reports = len(condition["report_submissions"])
-        logger.debug("Condition %s: %d clauses, %d deliverables, %d report submissions", cond_num, n_clauses, n_deliverables, n_reports)
+        logger.debug("Condition %s: %d clauses", cond_num, len(condition["clauses"]))
 
     return input_json
 
@@ -424,13 +416,17 @@ def extract_and_enrich_all(file_path: str, classification: Dict[str, Any]) -> Di
     logger.info("=== STEP 1: Extracting conditions ===")
     result = extract_conditions_from_pages(file_path, classification)
 
-    # Step 2: Enrich each condition (clauses + report_submissions)
-    logger.info("=== STEP 2: Enriching conditions (clauses & report submissions) ===")
+    # Step 2: Break each condition into its clause/subcondition structure
+    logger.info("=== STEP 2: Enriching conditions (clauses) ===")
     result = enrich_all_conditions(result)
 
     # Step 3: Extract deliverables using dedicated management plan extraction
     logger.info("=== STEP 3: Extracting deliverables ===")
     result = extract_management_plan_info_from_json(result)
+
+    # Step 4: Extract report submissions using dedicated report extraction
+    logger.info("=== STEP 4: Extracting report submissions ===")
+    result = extract_report_info_from_json(result)
 
     logger.info("=== Extraction complete: %d conditions ===", len(result.get('conditions', [])))
     return result

--- a/condition-cron/src/condition_cron/extraction/management_plans.py
+++ b/condition-cron/src/condition_cron/extraction/management_plans.py
@@ -9,6 +9,23 @@ from condition_cron.extraction.client import get_openai_client
 
 logger = logging.getLogger(__name__)
 
+# Matches the phase vocabulary used by condition-web's condition attribute
+# dropdowns (see condition-web Constants.ts SELECT_OPTIONS) so extracted
+# values land on options staff can actually select/see in the UI.
+SUBMISSION_MILESTONE_PHASES = [
+    "Pre-Construction",
+    "Construction",
+    "Commissioning",
+    "Operations",
+    "Care and Maintenance",
+    "Decommissioning",
+    "Closure",
+    "N/A",
+]
+
+IMPLEMENTATION_PHASES = SUBMISSION_MILESTONE_PHASES[:-1] + ["All Phases", "N/A"]
+
+
 def management_plan_required(input_condition_text: str) -> bool:
    
   tools = [
@@ -74,6 +91,10 @@ def extract_management_plan_info_using_gpt(condition_text: str) -> str:
                         "type": "string",
                         "description": "The name of the plan/report/proposal/etc. that the condition is requiring to be written. E.g. Air Quality Mitigation and Monitoring Plan, Marine Water Quality Management and Monitoring Plan for Operations, etc. Write it in title case (E.g. The Catcher in the Rye)."
                       },
+                      "management_plan_acronym": {
+                        "type": "string",
+                        "description": "The acronym for the plan, e.g. 'CEMP' for 'Construction Environmental Management Plan'. If the condition text explicitly defines an acronym for the plan (e.g., in parentheses after its name), use that exactly. Otherwise derive it from the initials of deliverable_name (e.g., 'Care and Maintenance Plan' -> 'CMP'), ignoring minor words like 'and', 'for', 'the'. Null if deliverable_name has no reasonable acronym."
+                      },
                       "is_plan": {
                         "type": "boolean",
                         "description": "Whether or not the deliverable is a \"Plan\" document (e.g., Management Plan, Monitoring Plan, Mitigation Plan, etc.). False if not specified."
@@ -81,7 +102,22 @@ def extract_management_plan_info_using_gpt(condition_text: str) -> str:
                       "approval_type": {
                         "type": "string",
                         "enum": ["Review", "Acceptance", "Satisfaction", "Approval", "Other"],
-                        "description": "The type of approval required when the plan/report/proposal/etc. is submitted to the EAO. Focus only on the clause describing the submission of the document itself — not clauses about how the plan must be implemented or carried out. Use \"Review\" if the submission clause indicates the document is provided for the EAO to review, or if no specific approval standard is mentioned — this is the default. Use \"Acceptance\" only if the submission clause explicitly requires the document to meet the EAO's acceptance standard. Use \"Satisfaction\" only if the submission clause explicitly requires the document to meet the EAO's satisfaction standard. Use \"Approval\" if the submission clause requires the document to be approved by the EAO. Use \"Other\" for any other explicit approval language. Many conditions include boilerplate language about implementation being to a regulator's standard — do not use that language to determine this field."
+                        "description": (
+                            "The type of approval required for the plan/report/proposal/etc. Consider the "
+                            "ENTIRE condition, not just the sentence where the document is first provided to "
+                            "the EAO — the true approval standard is often stated in a later clause about how "
+                            "the plan takes effect or must be implemented (e.g., 'the plan has no effect until "
+                            "approved by the EAO', 'must be developed to the satisfaction of the EAO'). Apply "
+                            "this priority, using the STRONGEST standard stated anywhere in the condition: "
+                            "\"Approval\" if any clause says the plan must be approved by the EAO, or has no "
+                            "effect / cannot proceed until approved. \"Acceptance\" if a clause requires the "
+                            "EAO's acceptance. \"Satisfaction\" if a clause requires the plan (or its "
+                            "development/implementation) to be to the satisfaction of the EAO. \"Review\" ONLY "
+                            "if the sole approval-related language anywhere in the condition is that the "
+                            "document is provided for the EAO's review, with no stronger standard stated "
+                            "elsewhere — this is also the default when no approval standard is stated at all. "
+                            "\"Other\" for any other explicit approval language that doesn't fit the above."
+                        ),
                       },
                       "stakeholders_to_consult": {
                         "type": "array",
@@ -103,14 +139,30 @@ def extract_management_plan_info_using_gpt(condition_text: str) -> str:
                       },
                       "related_phase": {
                         "type": "string",
-                        "description": "The phase of the project that the plan/report/proposal/etc.'s due date is related to. E.g. Construction, Construction of Upgrades, Operation, Decommissioning, etc. Write it in title case. Is null if not specified."
+                        "enum": SUBMISSION_MILESTONE_PHASES,
+                        "description": "The project phase that the plan/report/proposal/etc.'s SUBMISSION due date is related to (e.g., the phase referenced in 'a minimum of X days prior to the planned commencement of ___'). Use 'N/A' if not tied to a specific phase, or null if not specified at all."
                       },
-                      "days_prior_to_commencement": {
+                      "submission_time_value": {
                         "type": "integer",
-                        "description": "The number of days prior to the planned commencement that the plan/report/proposal/etc. must be provided to the EAO. Is negative if due after commencement. Is 0 if simple due before commencement without a specific number of days. Is null if not specified."
+                        "description": "The numeric magnitude of time relative to the milestone that the plan/report/proposal/etc. must be provided to the EAO (e.g., 60 for 'a minimum of 60 days prior to...', 30 for 'within 30 days after...'). Always non-negative — use submission_time_direction for before/after, not a negative number. Null if not specified."
+                      },
+                      "submission_time_unit": {
+                        "type": "string",
+                        "enum": ["Days", "Month(s)", "Year(s)"],
+                        "description": "The unit for submission_time_value. Null if not specified."
+                      },
+                      "submission_time_direction": {
+                        "type": "string",
+                        "enum": ["Before", "After", "Prior to"],
+                        "description": "Whether submission is due before or after the milestone. Use 'Prior to' when the condition text literally says 'prior to'. Use 'Before' for other before-the-milestone phrasing (e.g., 'a minimum of X days before'). Use 'After' for after-the-milestone phrasing (e.g., 'within X days after/following'). Null if not specified."
+                      },
+                      "implementation_phase": {
+                        "type": "string",
+                        "enum": IMPLEMENTATION_PHASES,
+                        "description": "The project phase(s) DURING WHICH the plan itself must be implemented/carried out (distinct from related_phase, which is about when the plan must be SUBMITTED). Look for language like 'must be implemented during/throughout ___'. Use 'All Phases' if implementation spans the whole project, 'N/A' if not tied to a specific phase, or null if not specified at all."
                       },
                   },
-                  "required": ["deliverable_name", "approval_type", "stakeholders_to_consult", "related_phase", "days_prior_to_commencement"],
+                  "required": ["deliverable_name", "approval_type", "stakeholders_to_consult", "related_phase", "submission_time_value", "submission_time_unit", "submission_time_direction", "implementation_phase"],
               }
             }
           },

--- a/condition-cron/src/condition_cron/extraction/reports.py
+++ b/condition-cron/src/condition_cron/extraction/reports.py
@@ -1,0 +1,269 @@
+"""Report submission extraction used by the cron extraction pipeline."""
+
+import json
+import logging
+
+from typing import Any, Dict, Optional
+
+from condition_cron.extraction.client import get_openai_client
+
+logger = logging.getLogger(__name__)
+
+REPORT_TYPES = [
+    "Compliance Notification",
+    "Compliance Self-Report",
+    "Management Plan Report",
+    "Project Status Notification",
+    "Monitoring/Technical Report",
+]
+
+REPORT_SUBTYPES = [
+    "Primary Contact Notification",
+    "Phase Status Notification",
+]
+
+REPORT_FREQUENCIES = ["As needed", "One time", "Annually", "Quarterly", "Other"]
+
+REPORT_PHASES = [
+    "All Phases",
+    "Pre-Construction",
+    "Construction",
+    "Commissioning",
+    "Operations",
+    "Care and Maintenance",
+    "Decommissioning",
+    "Closure",
+]
+
+
+def report_submission_required(input_condition_text: str) -> bool:
+
+  tools = [
+    {
+      "type": "function",
+      "function": {
+        "name": "extract_info",
+        "description": "If the condition requires a report, compliance notification, self-report, status notification, or monitoring/technical report to be submitted, extract the info related to it.",
+
+        "parameters": {
+          "type": "object",
+          "properties": {
+
+            "requires_report": {
+              "type": "boolean",
+              "description": (
+                  "Does this condition explicitly state that a NEW report, compliance notification, "
+                  "self-report, status notification, or monitoring/technical report must be submitted "
+                  "to the EAO? Mark False if the condition only describes how a report should be "
+                  "prepared or handled without requiring submission. Mark False if the condition only "
+                  "describes a general administrative process for how plans, programs, or other "
+                  "documents (that are themselves required by OTHER conditions) get reviewed, approved, "
+                  "or revised by the EAO — such a condition does not itself impose a new report and "
+                  "must not be treated as one, even though it mentions 'plan', 'program', or 'document'. "
+                  "Mark False when the only submission-like language is the plan/program/document's OWN "
+                  "development, initial submission to the EAO, or later updates/revisions/amendments to "
+                  "it — that lifecycle is captured separately as a management plan deliverable, not a "
+                  "report. Only mark True when the condition requires something to be reported IN "
+                  "ADDITION to the plan itself, such as periodic monitoring results, implementation "
+                  "status updates, or compliance status, submitted separately from (and typically after) "
+                  "the plan document."
+              ),
+            },
+
+          },
+          "required": ["requires_report"],
+        },
+
+      }
+    }
+  ]
+  messages = [{"role": "user", "content": f"Here is the text of a condition:\n\n{input_condition_text}"}]
+  client = get_openai_client()
+  completion = client.chat.completions.create(
+    model="gpt-4o-2024-05-13",
+    messages=messages,
+    tools=tools,
+    temperature=0.0,
+    tool_choice={"type": "function", "function": {"name": "extract_info"}}
+  )
+
+  result = json.loads(completion.choices[0].message.tool_calls[0].function.arguments)
+
+  if result:
+    return result["requires_report"]
+
+  else:
+    logger.error("report_submission_required: result is null")
+    return False
+
+
+def extract_report_info_using_gpt(condition_text: str) -> str:
+
+  tools = [
+    {
+      "type": "function",
+      "function": {
+        "name": "format_info",
+        "description": "Format the report submission information extracted from the condition.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "reports": {
+              "type": "array",
+              "description": (
+                  "One entry per distinct report this condition requires. If the SAME report recurs at "
+                  "multiple project phases or on multiple occasions (e.g., 30 days prior to Construction, "
+                  "then annually during Construction, then 30 days prior to Operations, and so on), that "
+                  "is still a SINGLE report — list every occasion in its submission_schedule rather than "
+                  "creating a separate reports[] entry per phase or per sub-clause."
+              ),
+              "items": {
+                "type": "object",
+                  "properties": {
+                      "report_type": {
+                        "type": "string",
+                        "enum": REPORT_TYPES,
+                        "description": (
+                            "The category of report this condition requires. "
+                            "'Compliance Notification': notifying the EAO of a non-compliance event, usually "
+                            "triggered 'As needed' with a short response window (e.g., 'Within 72 hours of "
+                            "non-compliance'). "
+                            "'Compliance Self-Report': a self-reported compliance status report, typically tied "
+                            "to project phases and/or a fixed annual date. "
+                            "'Management Plan Report': a report on the ongoing STATUS, RESULTS, or "
+                            "IMPLEMENTATION of a specific NAMED plan — see linked_management_plan_name. E.g. "
+                            "periodic monitoring results tied to a management plan, or an implementation "
+                            "status update. Do NOT use this for the plan's own development, initial "
+                            "submission to the EAO, or later updates/revisions to the plan document itself — "
+                            "that lifecycle is captured separately as a management plan deliverable, not a "
+                            "report. Only extract a Management Plan Report when something is submitted IN "
+                            "ADDITION to the plan document. "
+                            "'Project Status Notification': a notification about project status — see "
+                            "report_subtype. "
+                            "'Monitoring/Technical Report': a technical or environmental monitoring report."
+                        ),
+                      },
+                      "report_subtype": {
+                        "type": "string",
+                        "enum": REPORT_SUBTYPES,
+                        "description": (
+                            "Only set when report_type is 'Project Status Notification'. "
+                            "'Primary Contact Notification' if the report is about updating/confirming the certificate holder's primary contact. "
+                            "'Phase Status Notification' if the report is about the status of a project phase. "
+                            "Null for all other report types."
+                        ),
+                      },
+                      "report_title": {
+                        "type": "string",
+                        "description": "The name or title of the report as it appears in, or can be reasonably inferred from, the condition text (e.g., 'Annual Compliance Report', 'Air Quality Monitoring Report'). Title case."
+                      },
+                      "linked_management_plan_name": {
+                        "type": "string",
+                        "description": (
+                            "Only applicable when report_type is 'Management Plan Report'. The name of the "
+                            "specific plan this report is about (e.g., 'Aquatic Effects Monitoring Plan'), "
+                            "written in title case. Null if this report is not tied to a specific named plan."
+                        ),
+                      },
+                      "recipients": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "description": "The names of the stakeholders that the condition explicitly states should receive the report. Often the EAO or other government agencies. E.g. EAO, MOE, MOH."
+                        },
+                      },
+                      "submission_schedule": {
+                        "type": "array",
+                        "description": (
+                            "One entry per occasion or recurring schedule this report must be submitted. "
+                            "Most reports have just one entry, but reports tied to multiple project phases "
+                            "(e.g., a compliance status report due before and annually during each of "
+                            "Construction, Operations, and Closure) will have several."
+                        ),
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                              "phase": {
+                                "type": "string",
+                                "enum": REPORT_PHASES,
+                                "description": (
+                                    "The project phase this submission occasion relates to. Use "
+                                    "'All Phases' when the report recurs continuously across all phases, or "
+                                    "when it is event-triggered without a specific phase (e.g., a "
+                                    "non-compliance notification)."
+                                ),
+                              },
+                              "frequency": {
+                                "type": "string",
+                                "enum": REPORT_FREQUENCIES,
+                                "description": (
+                                    "How often the report must be submitted for this phase/occasion. Use "
+                                    "'As needed' when submission is triggered by an event (e.g., a "
+                                    "non-compliance, a contact change) rather than a fixed schedule — typical "
+                                    "for Compliance Notification and Project Status Notification. Use "
+                                    "'One time' for a single submission tied to a milestone or phase. Use "
+                                    "'Annually' or 'Quarterly' for a fixed recurring schedule. Use 'Other' "
+                                    "only for Compliance Self-Report or Management Plan Report entries whose "
+                                    "schedule doesn't fit the above — describe the actual schedule in 'timing' "
+                                    "instead."
+                                ),
+                              },
+                              "timing": {
+                                "type": "string",
+                                "description": (
+                                    "The specific timing or deadline language from the condition for this "
+                                    "occasion, written as closely to the original text as possible. E.g., "
+                                    "'Within 72 hours of non-compliance', 'At least 30 days prior to the start "
+                                    "of Construction', 'On or before March 31 each year after the start of "
+                                    "Operations', 'within 30 days after the issuance of this Certificate'."
+                                ),
+                              },
+                          },
+                          "required": ["phase", "frequency", "timing"],
+                        },
+                      },
+                  },
+                  "required": ["report_type", "report_title", "recipients", "submission_schedule"],
+              }
+            }
+          },
+          "required": ["reports"],
+        },
+      }
+    }
+  ]
+  messages = [{"role": "user", "content": f"Here is a condition written by the Environmental Assessment Office:\n\n{condition_text}\n\nFormat the information related to the report submission requirement(s). Remember: if the same report recurs across multiple phases or occasions, produce ONE reports[] entry for it with multiple submission_schedule items — do not split it into multiple reports[] entries."}]
+
+  client = get_openai_client()
+  completion = client.chat.completions.create(
+      model="gpt-4o-2024-05-13",
+      messages=messages,
+      tools=tools,
+      temperature=0.0,
+      tool_choice={"type": "function", "function": {"name": "format_info"}}
+  )
+
+  return completion.choices[0].message.tool_calls[0].function.arguments
+
+def extract_report_info(condition_text: str) -> Optional[str]:
+    if report_submission_required(condition_text):
+        logger.debug("This condition requires a report submission!")
+        return extract_report_info_using_gpt(condition_text)
+    else:
+        logger.debug("This condition does not require a report submission.")
+        return None
+
+def extract_report_info_from_json(input_json: Dict[str, Any]) -> Dict[str, Any]:
+    for condition in input_json.get("conditions", []):
+        logger.info("Checking if condition %s requires report submission(s):", condition.get('condition_number'))
+
+        condition_name = condition["condition_name"] + "\n\n" if condition["condition_name"] else ""
+        condition_text = condition_name + condition["condition_text"]
+        report_info = extract_report_info(condition_text)
+
+        if report_info is not None:
+            condition["report_submissions"] = json.loads(report_info)["reports"]
+        else:
+            condition["report_submissions"] = []
+
+    return input_json

--- a/condition-cron/src/condition_cron/extraction/schemas/enrichment_schema.json
+++ b/condition-cron/src/condition_cron/extraction/schemas/enrichment_schema.json
@@ -2,7 +2,7 @@
   "type": "function",
   "function": {
     "name": "enrich_condition",
-    "description": "Extract all structured details from a single condition: subconditions/clauses, deliverables (management plans), and report submission requirements.",
+    "description": "Break a single condition down into its nested clause/subcondition structure.",
     "parameters": {
       "type": "object",
       "properties": {
@@ -55,81 +55,9 @@
             },
             "required": ["clause_identifier", "clause_text", "subconditions"]
           }
-        },
-        "deliverables": {
-          "type": "array",
-          "description": "Management plans, reports, proposals, or other documents that the condition explicitly requires to be written/submitted. Empty array if no deliverables are required.",
-          "items": {
-            "type": "object",
-            "properties": {
-              "deliverable_name": {
-                "type": "string",
-                "description": "The name of the plan/report/proposal (e.g., 'Air Quality Mitigation and Monitoring Plan'). Title case."
-              },
-              "is_plan": {
-                "type": "boolean",
-                "description": "Whether the deliverable is a 'Plan' document (Management Plan, Monitoring Plan, Mitigation Plan, etc.). False if not a plan."
-              },
-              "approval_type": {
-                "type": "string",
-                "enum": ["Acceptance", "Satisfaction"],
-                "description": "Whether the document must be to the 'acceptance' or 'satisfaction' of the EAO. Null if not specified."
-              },
-              "stakeholders_to_consult": {
-                "type": "array",
-                "items": { "type": "string" },
-                "description": "Names of stakeholders the plan must be developed in consultation with (e.g., MOE, MOH, First Nations)."
-              },
-              "stakeholders_to_submit_to": {
-                "type": "array",
-                "items": { "type": "string" },
-                "description": "Names of stakeholders that should receive the plan (e.g., EAO, MOE)."
-              },
-              "fn_consultation_required": {
-                "type": "boolean",
-                "description": "Whether consultation with indigenous nations/First Nations is required. False if not explicitly specified."
-              },
-              "related_phase": {
-                "type": "string",
-                "description": "The project phase the deliverable's due date relates to (e.g., 'Construction', 'Operation', 'Decommissioning'). Title case. Null if not specified."
-              },
-              "days_prior_to_commencement": {
-                "type": "integer",
-                "description": "Days prior to planned commencement the document must be provided. Negative if due after commencement. 0 if simply 'before commencement' without specific days. Null if not specified."
-              }
-            },
-            "required": ["deliverable_name", "is_plan", "approval_type", "stakeholders_to_consult", "stakeholders_to_submit_to", "fn_consultation_required", "related_phase", "days_prior_to_commencement"]
-          }
-        },
-        "report_submissions": {
-          "type": "array",
-          "description": "Periodic or one-time reports that the condition requires to be submitted (separate from management plans/deliverables). Empty array if no report submissions are required.",
-          "items": {
-            "type": "object",
-            "properties": {
-              "requires_report_submission": {
-                "type": "boolean",
-                "description": "Whether this condition requires a report to be submitted."
-              },
-              "report_name": {
-                "type": "string",
-                "description": "The name or description of the report (e.g., 'Annual Compliance Report', 'Water Quality Monitoring Report'). Title case."
-              },
-              "report_frequency": {
-                "type": "string",
-                "description": "How often the report must be submitted (e.g., 'Annual', 'Quarterly', 'Monthly', 'Semi-annual', 'Upon request', 'One-time', 'As needed'). Null if not specified."
-              },
-              "report_recipients": {
-                "type": "array",
-                "items": { "type": "string" },
-                "description": "Names of parties/agencies the report must be submitted to."
-              }
-            },
-            "required": ["requires_report_submission", "report_name", "report_frequency", "report_recipients"]
-          }
         }
       },
-      "required": ["clauses", "deliverables", "report_submissions"]
+      "required": ["clauses"]
     }
   }
 }


### PR DESCRIPTION
Ticket: https://eao-dst.atlassian.net/browse/CR-208

- Removed redundant deliverables/report_submissions extraction from the combined enrichment call (already produced by dedicated calls)
- reports.py: grouped recurring report submissions into one entry with a phase/frequency/timing schedule
- management_plans.py: added missing acronym & implementation_phase fields; replaced signed day-count with explicit value/unit/direction fields; improved approval_type detection logic
- extraction_import_service.py: fixed dropped "submission milestone" attribute (missing alias), added formatting for new time fields, removed redundant deliverable_name attribute
